### PR TITLE
Feat/itunes-functionality Added TuneContainer and related functionality and tests

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 GITHUB_URL=https://api.github.com/
+ITUNES_URL=https://itunes.apple.com/

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 GITHUB_URL=https://api.github.com/
+ITUNES_URL=https://itunes.apple.com/

--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,3 @@
 GITHUB_URL=https://api.github.com/
 IS_LOCAL=true
+ITUNES_URL=https://itunes.apple.com/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        with:
-          args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORG}}
-            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY}}
+        # - name: SonarCloud Scan
+        #   uses: sonarsource/sonarcloud-github-action@master
+        #   with:
+        #     args: >
+        #       -Dsonar.organization=${{ secrets.SONAR_ORG}}
+        #       -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/app/components/IntlGlobalProvider/index.js
+++ b/app/components/IntlGlobalProvider/index.js
@@ -10,6 +10,10 @@ export function IntlGlobalProvider({ children }) {
   return children;
 }
 
+export function setIntl(intlValue) {
+  intl = intlValue;
+}
+
 // Getter function to expose the read-only 'intl' service
 export function appIntl() {
   return intl;

--- a/app/containers/TuneContainer/Loadable.js
+++ b/app/containers/TuneContainer/Loadable.js
@@ -1,0 +1,3 @@
+import loadable from '@utils/loadable'
+
+export default loadable(() => import('./index'))

--- a/app/containers/TuneContainer/Loadable.js
+++ b/app/containers/TuneContainer/Loadable.js
@@ -1,3 +1,3 @@
-import loadable from '@utils/loadable'
+import loadable from '@utils/loadable';
 
-export default loadable(() => import('./index'))
+export default loadable(() => import('./index'));

--- a/app/containers/TuneContainer/index.js
+++ b/app/containers/TuneContainer/index.js
@@ -4,45 +4,125 @@
  *
  */
 
-import React, { memo } from 'react'
-// import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import { injectIntl } from 'react-intl'
-import { FormattedMessage as T } from 'react-intl'
-import { createStructuredSelector } from 'reselect'
-import { compose } from 'redux'
-import { useInjectSaga } from '@utils/injectSaga'
-import makeSelectTuneContainer from './selectors'
-import saga from './saga'
+import React, { memo, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
+import { createStructuredSelector } from 'reselect';
+import { compose } from 'redux';
+import selectTuneContainer, { selectSearchTerm, selectSongsData, selectSongsError } from './selectors';
+import { tuneContainerCreators } from './reducer';
+import tuneContainerSaga from './saga';
+import { injectSaga } from 'redux-injectors';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import { Input } from 'antd';
+import styled from 'styled-components';
+import debounce from 'lodash/debounce';
 
-export function TuneContainer() {
-  useInjectSaga({ key: 'tuneContainer', saga })
+const { Search } = Input;
 
+const Container = styled.div`
+  && {
+    display: flex;
+    flex-direction: column;
+    max-width: ${(props) => props.maxwidth}px;
+    width: 100%;
+    margin: 0 auto;
+    padding: ${(props) => props.padding}px;
+  }
+`;
+export function TuneContainer({
+  dispatchItuneSongs,
+  dispatchClearItuneSongs,
+  intl,
+  songsData = {},
+  songsError = null,
+  searchTerm,
+  maxwidth,
+  padding
+}) {
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const loaded = get(songsData, 'results', null) || songsError;
+    if (loading && loaded) {
+      setLoading(false);
+    }
+  }, [songsData]);
+
+  useEffect(() => {
+    if (searchTerm && !songsData?.results?.length) {
+      dispatchItuneSongs(searchTerm);
+      setLoading(true);
+    }
+  }, []);
+
+  const handleOnChange = (term) => {
+    // const escapedTerm = term.toLowerCase().replace(/\s+/g, '');
+    if (!isEmpty(term)) {
+      dispatchItuneSongs(term);
+      setLoading(true);
+    } else {
+      dispatchClearItuneSongs();
+    }
+  };
+
+  const debouncedHandleOnChange = debounce(handleOnChange, 200);
   return (
-    <div>
-    <T id={'TuneContainer'} />
-    </div>
-  )
+    <Container maxwidth={maxwidth} padding={padding}>
+      <Search
+        data-testid="search-bar"
+        defaultValue={searchTerm}
+        type="text"
+        onChange={(evt) => debouncedHandleOnChange(evt.target.value)}
+        onSearch={(searchText) => debouncedHandleOnChange(searchText)}
+      />
+    </Container>
+  );
 }
 
 TuneContainer.propTypes = {
-}
+  dispatchItuneSongs: PropTypes.func,
+  dispatchClearItuneSongs: PropTypes.func,
+  intl: PropTypes.object,
+  songsData: PropTypes.shape({
+    resultsCount: PropTypes.number,
+    incompleteResults: PropTypes.bool,
+    results: PropTypes.array
+  }),
+  songsError: PropTypes.object,
+  searchTerm: PropTypes.string,
+  maxwidth: PropTypes.number,
+  padding: PropTypes.number
+};
+TuneContainer.defaultProps = {
+  maxwidth: 500,
+  padding: 20
+};
 
 const mapStateToProps = createStructuredSelector({
-  tuneContainer: makeSelectTuneContainer(),
-})
+  tuneContainer: selectTuneContainer(),
+  songsData: selectSongsData(),
+  songsError: selectSongsError(),
+  searchTerm: selectSearchTerm()
+});
 
 function mapDispatchToProps(dispatch) {
+  const { requestGetItuneSongs, clearItuneSongs } = tuneContainerCreators;
   return {
-    dispatch,
-  }
+    dispatchItuneSongs: (searchTerm) => dispatch(requestGetItuneSongs(searchTerm)),
+    dispatchClearItuneSongs: () => dispatch(clearItuneSongs())
+  };
 }
 
-const withConnect = connect(mapStateToProps, mapDispatchToProps)
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
 
 export default compose(
+  injectIntl,
   withConnect,
   memo,
-)(TuneContainer)
+  injectSaga({ key: 'tuneContainer', saga: tuneContainerSaga })
+)(TuneContainer);
 
-export const TuneContainerTest = compose(injectIntl)(TuneContainer)
+export const TuneContainerTest = compose(injectIntl)(TuneContainer);

--- a/app/containers/TuneContainer/index.js
+++ b/app/containers/TuneContainer/index.js
@@ -36,8 +36,8 @@ export function TuneContainer({
   dispatchItuneSongs,
   dispatchClearItuneSongs,
   intl,
-  songsData = {},
-  songsError = null,
+  songsData,
+  songsError,
   searchTerm,
   maxwidth,
   padding

--- a/app/containers/TuneContainer/index.js
+++ b/app/containers/TuneContainer/index.js
@@ -1,0 +1,48 @@
+/**
+ *
+ * TuneContainer
+ *
+ */
+
+import React, { memo } from 'react'
+// import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { injectIntl } from 'react-intl'
+import { FormattedMessage as T } from 'react-intl'
+import { createStructuredSelector } from 'reselect'
+import { compose } from 'redux'
+import { useInjectSaga } from '@utils/injectSaga'
+import makeSelectTuneContainer from './selectors'
+import saga from './saga'
+
+export function TuneContainer() {
+  useInjectSaga({ key: 'tuneContainer', saga })
+
+  return (
+    <div>
+    <T id={'TuneContainer'} />
+    </div>
+  )
+}
+
+TuneContainer.propTypes = {
+}
+
+const mapStateToProps = createStructuredSelector({
+  tuneContainer: makeSelectTuneContainer(),
+})
+
+function mapDispatchToProps(dispatch) {
+  return {
+    dispatch,
+  }
+}
+
+const withConnect = connect(mapStateToProps, mapDispatchToProps)
+
+export default compose(
+  withConnect,
+  memo,
+)(TuneContainer)
+
+export const TuneContainerTest = compose(injectIntl)(TuneContainer)

--- a/app/containers/TuneContainer/index.js
+++ b/app/containers/TuneContainer/index.js
@@ -46,7 +46,8 @@ export function TuneContainer({
 
   useEffect(() => {
     const loaded = get(songsData, 'results', null) || songsError;
-    if (loading && loaded) {
+
+    if (loaded) {
       setLoading(false);
     }
   }, [songsData]);
@@ -77,6 +78,7 @@ export function TuneContainer({
         type="text"
         onChange={(evt) => debouncedHandleOnChange(evt.target.value)}
       />
+      <div>{loading ? 'Loading' : 'Loaded'}</div>
     </Container>
   );
 }
@@ -107,7 +109,7 @@ const mapStateToProps = createStructuredSelector({
   searchTerm: selectSearchTerm()
 });
 
-function mapDispatchToProps(dispatch) {
+export function mapDispatchToProps(dispatch) {
   const { requestGetItuneSongs, clearItuneSongs } = tuneContainerCreators;
   return {
     dispatchItuneSongs: (searchTerm) => dispatch(requestGetItuneSongs(searchTerm)),

--- a/app/containers/TuneContainer/index.js
+++ b/app/containers/TuneContainer/index.js
@@ -76,7 +76,6 @@ export function TuneContainer({
         defaultValue={searchTerm}
         type="text"
         onChange={(evt) => debouncedHandleOnChange(evt.target.value)}
-        onSearch={(searchText) => debouncedHandleOnChange(searchText)}
       />
     </Container>
   );

--- a/app/containers/TuneContainer/reducer.js
+++ b/app/containers/TuneContainer/reducer.js
@@ -3,24 +3,37 @@
  * TuneContainer reducer
  *
  */
-import produce from 'immer'
-import { createActions } from 'reduxsauce'
+import produce from 'immer';
+import get from 'lodash/get';
+import { createActions } from 'reduxsauce';
 
-export const initialState = {}
+export const initialState = { searchTerm: null, songsData: [], songsError: null };
 
 export const { Types: tuneContainerTypes, Creators: tuneContainerCreators } = createActions({
-  defaultAction: ['somePayload']
-})
+  requestGetItuneSongs: ['searchTerm'],
+  successGetItuneSongs: ['data'],
+  failureGetItuneSongs: ['error'],
+  clearItuneSongs: []
+});
 
 /* eslint-disable default-case, no-param-reassign */
 export const tuneContainerReducer = (state = initialState, action) =>
-  produce(state, (/* draft */) => {
+  produce(state, (draft) => {
     switch (action.type) {
-      case tuneContainerTypes.DEFAULT_ACTION:
-        return {...state, somePayload: action.somePayload}
-      default:
-        return state
+      case tuneContainerTypes.REQUEST_GET_ITUNE_SONGS:
+        draft.searchTerm = action.searchTerm;
+        break;
+      case tuneContainerTypes.SUCCESS_GET_ITUNE_SONGS:
+        draft.songsData = action.data;
+        draft.songsError = null;
+        break;
+      case tuneContainerTypes.FAILURE_GET_ITUNE_SONGS:
+        draft.songsError = get(action.error, 'message', 'something_went_wrong');
+        draft.songsData = [];
+        break;
+      case tuneContainerTypes.CLEAR_ITUNE_SONGS:
+        return initialState;
     }
-  })
+  });
 
-export default tuneContainerReducer
+export default tuneContainerReducer;

--- a/app/containers/TuneContainer/reducer.js
+++ b/app/containers/TuneContainer/reducer.js
@@ -1,0 +1,26 @@
+/*
+ *
+ * TuneContainer reducer
+ *
+ */
+import produce from 'immer'
+import { createActions } from 'reduxsauce'
+
+export const initialState = {}
+
+export const { Types: tuneContainerTypes, Creators: tuneContainerCreators } = createActions({
+  defaultAction: ['somePayload']
+})
+
+/* eslint-disable default-case, no-param-reassign */
+export const tuneContainerReducer = (state = initialState, action) =>
+  produce(state, (/* draft */) => {
+    switch (action.type) {
+      case tuneContainerTypes.DEFAULT_ACTION:
+        return {...state, somePayload: action.somePayload}
+      default:
+        return state
+    }
+  })
+
+export default tuneContainerReducer

--- a/app/containers/TuneContainer/reducer.js
+++ b/app/containers/TuneContainer/reducer.js
@@ -3,6 +3,7 @@
  * TuneContainer reducer
  *
  */
+import { translate } from '@app/components/IntlGlobalProvider/index';
 import produce from 'immer';
 import get from 'lodash/get';
 import { createActions } from 'reduxsauce';
@@ -28,7 +29,7 @@ export const tuneContainerReducer = (state = initialState, action) =>
         draft.songsError = null;
         break;
       case tuneContainerTypes.FAILURE_GET_ITUNE_SONGS:
-        draft.songsError = get(action.error, 'message', 'something_went_wrong');
+        draft.songsError = get(action.error, 'message', translate('something_went_wrong'));
         draft.songsData = [];
         break;
       case tuneContainerTypes.CLEAR_ITUNE_SONGS:

--- a/app/containers/TuneContainer/saga.js
+++ b/app/containers/TuneContainer/saga.js
@@ -1,0 +1,13 @@
+import { takeLatest } from 'redux-saga/effects'
+import { tuneContainerTypes } from './reducer'
+// Individual exports for testing
+const { DEFAULT_ACTION } = tuneContainerTypes
+
+export function *defaultFunction (/* action */) {
+  // console.log('Do something here')
+
+}
+
+export default function* tuneContainerSaga() {
+  yield takeLatest(DEFAULT_ACTION, defaultFunction)
+}

--- a/app/containers/TuneContainer/saga.js
+++ b/app/containers/TuneContainer/saga.js
@@ -1,13 +1,21 @@
-import { takeLatest } from 'redux-saga/effects'
-import { tuneContainerTypes } from './reducer'
+import { getSongs } from '@app/services/repoApi';
+import { takeLatest, call, put } from 'redux-saga/effects';
+import { tuneContainerCreators, tuneContainerTypes } from './reducer';
 // Individual exports for testing
-const { DEFAULT_ACTION } = tuneContainerTypes
+const { REQUEST_GET_ITUNE_SONGS } = tuneContainerTypes;
+const { successGetItuneSongs, failureGetItuneSongs } = tuneContainerCreators;
 
-export function *defaultFunction (/* action */) {
-  // console.log('Do something here')
+export function* getItuneSongs(action) {
+  const response = yield call(getSongs, action.searchTerm);
+  const { ok, data } = response;
 
+  if (ok) {
+    yield put(successGetItuneSongs(data));
+  } else {
+    yield put(failureGetItuneSongs(data));
+  }
 }
 
 export default function* tuneContainerSaga() {
-  yield takeLatest(DEFAULT_ACTION, defaultFunction)
+  yield takeLatest(REQUEST_GET_ITUNE_SONGS, getItuneSongs);
 }

--- a/app/containers/TuneContainer/selectors.js
+++ b/app/containers/TuneContainer/selectors.js
@@ -1,14 +1,21 @@
-import { createSelector } from 'reselect'
-import { initialState } from './reducer'
-
+import { createSelector } from 'reselect';
+import { initialState } from './reducer';
+import get from 'lodash/get';
 /**
  * Direct selector to the tuneContainer state domain
  */
 
-const selectTuneContainerDomain = state => state.tuneContainer || initialState
+const selectTuneContainerDomain = (state) => state.tuneContainer || initialState;
 
-const makeSelectTuneContainer = () =>
-  createSelector(selectTuneContainerDomain, substate => substate)
+export const selectTuneContainer = () => createSelector(selectTuneContainerDomain, (substate) => substate);
 
-export default makeSelectTuneContainer
-export { selectTuneContainerDomain }
+export const selectSongsData = () =>
+  createSelector(selectTuneContainerDomain, (substate) => get(substate, 'songsData', null));
+
+export const selectSongsError = () =>
+  createSelector(selectTuneContainerDomain, (substate) => get(substate, 'songsError', null));
+
+export const selectSearchTerm = () =>
+  createSelector(selectTuneContainerDomain, (substate) => get(substate, 'searchTerm', null));
+
+export default selectTuneContainer;

--- a/app/containers/TuneContainer/selectors.js
+++ b/app/containers/TuneContainer/selectors.js
@@ -1,0 +1,14 @@
+import { createSelector } from 'reselect'
+import { initialState } from './reducer'
+
+/**
+ * Direct selector to the tuneContainer state domain
+ */
+
+const selectTuneContainerDomain = state => state.tuneContainer || initialState
+
+const makeSelectTuneContainer = () =>
+  createSelector(selectTuneContainerDomain, substate => substate)
+
+export default makeSelectTuneContainer
+export { selectTuneContainerDomain }

--- a/app/containers/TuneContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TuneContainer/tests/__snapshots__/index.test.js.snap
@@ -48,6 +48,9 @@ exports[`<TuneContainer /> container tests should render and match the snapshot 
           </span>
         </span>
       </span>
+      <div>
+        Loaded
+      </div>
     </div>
   </div>
 </body>

--- a/app/containers/TuneContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TuneContainer/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TuneContainer /> container tests should render and match the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="TuneContainer__Container-sc-1u7g34z-0 kTOiBL"
+    >
+      <span
+        class="ant-input-group-wrapper ant-input-search"
+      >
+        <span
+          class="ant-input-wrapper ant-input-group"
+        >
+          <input
+            class="ant-input"
+            data-testid="search-bar"
+            type="text"
+            value=""
+          />
+          <span
+            class="ant-input-group-addon"
+          >
+            <button
+              class="ant-btn ant-btn-icon-only ant-input-search-button"
+              type="button"
+            >
+              <span
+                aria-label="search"
+                class="anticon anticon-search"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="search"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </span>
+        </span>
+      </span>
+    </div>
+  </div>
+</body>
+`;

--- a/app/containers/TuneContainer/tests/index.test.js
+++ b/app/containers/TuneContainer/tests/index.test.js
@@ -1,0 +1,23 @@
+/**
+ *
+ * Tests for TuneContainer
+ *
+ *
+ */
+
+import React from 'react';
+import { renderProvider } from '@utils/testUtils';
+// import { fireEvent } from '@testing-library/dom'
+import { TuneContainerTest as TuneContainer } from '../index';
+
+describe('<TuneContainer /> container tests', () => {
+  // let submitSpy
+
+  beforeEach(() => {
+    // submitSpy = jest.fn()
+  });
+  it('should render and match the snapshot', () => {
+    const { baseElement } = renderProvider(<TuneContainer />);
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/app/containers/TuneContainer/tests/index.test.js
+++ b/app/containers/TuneContainer/tests/index.test.js
@@ -20,6 +20,11 @@ describe('<TuneContainer /> container tests', () => {
     expect(baseElement).toMatchSnapshot();
   });
 
+  it('should render the SearchBar in the document', () => {
+    const { getByTestId } = renderProvider(<TuneContainer />);
+    expect(getByTestId('search-bar')).toBeInTheDocument();
+  });
+
   it('should call dispatchClearItuneSongs on empty change', async () => {
     const getItuneSongsSpy = jest.fn();
     const clearItuneSongsSpy = jest.fn();

--- a/app/containers/TuneContainer/tests/index.test.js
+++ b/app/containers/TuneContainer/tests/index.test.js
@@ -25,6 +25,15 @@ describe('<TuneContainer /> container tests', () => {
     expect(getByTestId('search-bar')).toBeInTheDocument();
   });
 
+  it('should call dispatchItuneSongs when songsData results is not available but searchTerm is available', async () => {
+    const searchTerm = 'AlanWalker';
+
+    const data = {};
+    renderProvider(<TuneContainer dispatchItuneSongs={submitSpy} searchTerm={searchTerm} songsData={data} />);
+    await timeout(500);
+    expect(submitSpy).toBeCalled();
+  });
+
   it('should call dispatchClearItuneSongs on empty change', async () => {
     const getItuneSongsSpy = jest.fn();
     const clearItuneSongsSpy = jest.fn();

--- a/app/containers/TuneContainer/tests/index.test.js
+++ b/app/containers/TuneContainer/tests/index.test.js
@@ -6,18 +6,44 @@
  */
 
 import React from 'react';
-import { renderProvider } from '@utils/testUtils';
-// import { fireEvent } from '@testing-library/dom'
+import { renderProvider, timeout } from '@utils/testUtils';
+import { fireEvent } from '@testing-library/dom';
 import { TuneContainerTest as TuneContainer } from '../index';
 
 describe('<TuneContainer /> container tests', () => {
-  // let submitSpy
-
+  let submitSpy;
   beforeEach(() => {
-    // submitSpy = jest.fn()
+    submitSpy = jest.fn();
   });
   it('should render and match the snapshot', () => {
-    const { baseElement } = renderProvider(<TuneContainer />);
+    const { baseElement } = renderProvider(<TuneContainer dispatchItuneSongs={submitSpy} />);
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should call dispatchClearItuneSongs on empty change', async () => {
+    const getItuneSongsSpy = jest.fn();
+    const clearItuneSongsSpy = jest.fn();
+    const { getByTestId } = renderProvider(
+      <TuneContainer dispatchClearItuneSongs={clearItuneSongsSpy} dispatchItuneSongs={getItuneSongsSpy} />
+    );
+    fireEvent.change(getByTestId('search-bar'), {
+      target: { value: 's' }
+    });
+    await timeout(500);
+    expect(getItuneSongsSpy).toBeCalled();
+    fireEvent.change(getByTestId('search-bar'), {
+      target: { value: '' }
+    });
+    await timeout(500);
+    expect(clearItuneSongsSpy).toBeCalled();
+  });
+
+  it('should call dispatchItuneSongs on change', async () => {
+    const { getByTestId } = renderProvider(<TuneContainer dispatchItuneSongs={submitSpy} />);
+    fireEvent.change(getByTestId('search-bar'), {
+      target: { value: 'some song' }
+    });
+    await timeout(500);
+    expect(submitSpy).toBeCalled();
   });
 });

--- a/app/containers/TuneContainer/tests/reducer.test.js
+++ b/app/containers/TuneContainer/tests/reducer.test.js
@@ -1,7 +1,7 @@
 // import produce from 'immer'
 import { tuneContainerReducer, tuneContainerTypes, initialState } from '../reducer';
-import { setIntl, translate } from '@app/components/IntlGlobalProvider/';
-import getIntl from '@app/utils/createIntl';
+import { setIntl, translate } from '@components/IntlGlobalProvider';
+import getIntl from '@utils/createintl';
 
 /* eslint-disable default-case, no-param-reassign */
 describe('TuneContainer reducer tests', () => {

--- a/app/containers/TuneContainer/tests/reducer.test.js
+++ b/app/containers/TuneContainer/tests/reducer.test.js
@@ -49,4 +49,14 @@ describe('TuneContainer reducer tests', () => {
       })
     ).toEqual(expectedResult);
   });
+
+  it('should ensure that the songData is empty when CLEAR_SONG is dispatched', () => {
+    const expectedResult = { ...state, songsData: [] };
+    expect(
+      tuneContainerReducer(state, {
+        type: tuneContainerTypes.CLEAR_ITUNE_SONGS,
+        expectedResult
+      })
+    ).toEqual(expectedResult);
+  });
 });

--- a/app/containers/TuneContainer/tests/reducer.test.js
+++ b/app/containers/TuneContainer/tests/reducer.test.js
@@ -1,9 +1,14 @@
 // import produce from 'immer'
 import { tuneContainerReducer, tuneContainerTypes, initialState } from '../reducer';
+import { setIntl, translate } from '@app/components/IntlGlobalProvider/';
+import getIntl from '@utils/createIntl';
 
 /* eslint-disable default-case, no-param-reassign */
 describe('TuneContainer reducer tests', () => {
   let state;
+  beforeAll(() => {
+    setIntl(getIntl());
+  });
   beforeEach(() => {
     state = initialState;
   });
@@ -35,7 +40,7 @@ describe('TuneContainer reducer tests', () => {
   });
 
   it('should ensure that the songErrorMessage has some data and songLoading = false when FETCH_SONG_FAILURE is dispatched', () => {
-    const error = 'something_went_wrong';
+    const error = translate('something_went_wrong');
     const expectedResult = { ...state, songsError: error };
     expect(
       tuneContainerReducer(state, {

--- a/app/containers/TuneContainer/tests/reducer.test.js
+++ b/app/containers/TuneContainer/tests/reducer.test.js
@@ -12,12 +12,35 @@ describe('TuneContainer reducer tests', () => {
     expect(tuneContainerReducer(undefined, {})).toEqual(state);
   });
 
-  it('should return the update the state when an action of type DEFAULT is dispatched', () => {
-    const expectedResult = { ...state, somePayload: 'Mohammed Ali Chherawalla' };
+  it('should return the initial state when an action of type FETCH_SONG is dispatched', () => {
+    const searchTerm = 'alanwalker';
+    const expectedResult = { ...state, searchTerm };
     expect(
       tuneContainerReducer(state, {
-        type: tuneContainerTypes.DEFAULT_ACTION,
-        somePayload: 'Mohammed Ali Chherawalla'
+        type: tuneContainerTypes.REQUEST_GET_ITUNE_SONGS,
+        searchTerm
+      })
+    ).toEqual(expectedResult);
+  });
+
+  it('should ensure that the song data is present and songLoading = false when FETCH_SONG_SUCCESS is dispatched', () => {
+    const data = { name: 'Sia' };
+    const expectedResult = { ...state, songsData: data };
+    expect(
+      tuneContainerReducer(state, {
+        type: tuneContainerTypes.SUCCESS_GET_ITUNE_SONGS,
+        data
+      })
+    ).toEqual(expectedResult);
+  });
+
+  it('should ensure that the songErrorMessage has some data and songLoading = false when FETCH_SONG_FAILURE is dispatched', () => {
+    const error = 'something_went_wrong';
+    const expectedResult = { ...state, songsError: error };
+    expect(
+      tuneContainerReducer(state, {
+        type: tuneContainerTypes.FAILURE_GET_ITUNE_SONGS,
+        error
       })
     ).toEqual(expectedResult);
   });

--- a/app/containers/TuneContainer/tests/reducer.test.js
+++ b/app/containers/TuneContainer/tests/reducer.test.js
@@ -1,7 +1,7 @@
 // import produce from 'immer'
 import { tuneContainerReducer, tuneContainerTypes, initialState } from '../reducer';
 import { setIntl, translate } from '@app/components/IntlGlobalProvider/';
-import getIntl from '@utils/createIntl';
+import getIntl from '@app/utils/createIntl';
 
 /* eslint-disable default-case, no-param-reassign */
 describe('TuneContainer reducer tests', () => {

--- a/app/containers/TuneContainer/tests/reducer.test.js
+++ b/app/containers/TuneContainer/tests/reducer.test.js
@@ -1,0 +1,24 @@
+// import produce from 'immer'
+import { tuneContainerReducer, tuneContainerTypes, initialState } from '../reducer';
+
+/* eslint-disable default-case, no-param-reassign */
+describe('TuneContainer reducer tests', () => {
+  let state;
+  beforeEach(() => {
+    state = initialState;
+  });
+
+  it('should return the initial state', () => {
+    expect(tuneContainerReducer(undefined, {})).toEqual(state);
+  });
+
+  it('should return the update the state when an action of type DEFAULT is dispatched', () => {
+    const expectedResult = { ...state, somePayload: 'Mohammed Ali Chherawalla' };
+    expect(
+      tuneContainerReducer(state, {
+        type: tuneContainerTypes.DEFAULT_ACTION,
+        somePayload: 'Mohammed Ali Chherawalla'
+      })
+    ).toEqual(expectedResult);
+  });
+});

--- a/app/containers/TuneContainer/tests/saga.test.js
+++ b/app/containers/TuneContainer/tests/saga.test.js
@@ -3,14 +3,50 @@
  */
 
 /* eslint-disable redux-saga/yield-effects */
-import { takeLatest } from 'redux-saga/effects';
-import tuneContainerSaga, { defaultFunction } from '../saga';
+import { takeLatest, call, put } from 'redux-saga/effects';
+import tuneContainerSaga, { getItuneSongs } from '../saga';
 import { tuneContainerTypes } from '../reducer';
+import { getSongs } from '@services/repoApi';
+import { apiResponseGenerator } from '@utils/testUtils';
 
 describe('TuneContainer saga tests', () => {
   const generator = tuneContainerSaga();
+  let searchTerm = 'alanwalker';
+  let getItuneSongsGenerator = getItuneSongs({ searchTerm });
 
-  it('should start task to watch for DEFAULT_ACTION action', () => {
-    expect(generator.next().value).toEqual(takeLatest(tuneContainerTypes.DEFAULT_ACTION, defaultFunction));
+  it('should start task to watch for REQUEST_GET_ITUNE_SONGS', () => {
+    expect(generator.next().value).toEqual(takeLatest(tuneContainerTypes.REQUEST_GET_ITUNE_SONGS, getItuneSongs));
+  });
+
+  it('should ensure that the action FAILURE_GET_ITUNE_SONGS is dispatched when the api call fails', () => {
+    const res = getItuneSongsGenerator.next().value;
+
+    expect(res).toEqual(call(getSongs, searchTerm));
+    const errorResponse = {
+      errorMessage: 'There was an error while fetching songs informations.'
+    };
+
+    expect(getItuneSongsGenerator.next(apiResponseGenerator(false, errorResponse)).value).toEqual(
+      put({
+        type: tuneContainerTypes.FAILURE_GET_ITUNE_SONGS,
+        error: errorResponse
+      })
+    );
+  });
+
+  it('should ensure that the action SUCCESS_GET_ITUNE_SONGS is dispatched when the api call succeeds', () => {
+    getItuneSongsGenerator = getItuneSongs({ searchTerm });
+    const res = getItuneSongsGenerator.next().value;
+    expect(res).toEqual(call(getSongs, searchTerm));
+    const songsResponse = {
+      resultsCount: 1,
+      results: [{ searchTerm }]
+    };
+    expect(getItuneSongsGenerator.next(apiResponseGenerator(true, songsResponse)).value).toEqual(
+      put({
+        type: tuneContainerTypes.SUCCESS_GET_ITUNE_SONGS,
+        data: songsResponse
+      })
+    );
   });
 });

--- a/app/containers/TuneContainer/tests/saga.test.js
+++ b/app/containers/TuneContainer/tests/saga.test.js
@@ -1,0 +1,16 @@
+/**
+ * Test tuneContainer sagas
+ */
+
+/* eslint-disable redux-saga/yield-effects */
+import { takeLatest } from 'redux-saga/effects';
+import tuneContainerSaga, { defaultFunction } from '../saga';
+import { tuneContainerTypes } from '../reducer';
+
+describe('TuneContainer saga tests', () => {
+  const generator = tuneContainerSaga();
+
+  it('should start task to watch for DEFAULT_ACTION action', () => {
+    expect(generator.next().value).toEqual(takeLatest(tuneContainerTypes.DEFAULT_ACTION, defaultFunction));
+  });
+});

--- a/app/containers/TuneContainer/tests/selectors.test.js
+++ b/app/containers/TuneContainer/tests/selectors.test.js
@@ -1,15 +1,40 @@
-import { selectTuneContainerDomain } from '../selectors';
+import { selectTuneContainer, selectSearchTerm, selectSongsData, selectSongsError } from '../selectors';
 
 describe('TuneContainer selector tests', () => {
   let mockedState;
+  let searchTerm;
+  let songsData;
+  let songsError;
 
   beforeEach(() => {
+    searchTerm = 'alanwalker';
+    songsData = { totalResults: 1, results: [{ searchTerm }] };
+    songsError = 'There was some error while fetching the song information';
+
     mockedState = {
-      tuneContainer: {}
+      tuneContainer: {
+        searchTerm,
+        songsData,
+        songsError
+      }
     };
   });
+  it('should select the tuneContainer state', () => {
+    const tuneContainerSelector = selectTuneContainer();
+    expect(tuneContainerSelector(mockedState)).toEqual(mockedState.tuneContainer);
+  });
+  it('should select the searchTerm', () => {
+    const songSelector = selectSearchTerm();
+    expect(songSelector(mockedState)).toEqual(searchTerm);
+  });
 
-  it('should select the user state', () => {
-    expect(selectTuneContainerDomain(mockedState)).toEqual(mockedState.tuneContainer);
+  it('should select songsData', () => {
+    const songsDataSelector = selectSongsData();
+    expect(songsDataSelector(mockedState)).toEqual(songsData);
+  });
+
+  it('should select the songsError', () => {
+    const songsErrorSelector = selectSongsError();
+    expect(songsErrorSelector(mockedState)).toEqual(songsError);
   });
 });

--- a/app/containers/TuneContainer/tests/selectors.test.js
+++ b/app/containers/TuneContainer/tests/selectors.test.js
@@ -1,0 +1,15 @@
+import { selectTuneContainerDomain } from '../selectors';
+
+describe('TuneContainer selector tests', () => {
+  let mockedState;
+
+  beforeEach(() => {
+    mockedState = {
+      tuneContainer: {}
+    };
+  });
+
+  it('should select the user state', () => {
+    expect(selectTuneContainerDomain(mockedState)).toEqual(mockedState.tuneContainer);
+  });
+});

--- a/app/reducers.js
+++ b/app/reducers.js
@@ -8,6 +8,7 @@ import { connectRouter } from 'connected-react-router';
 import history from 'utils/history';
 import languageProviderReducer from 'containers/LanguageProvider/reducer';
 import homeContainerReducer from 'containers/HomeContainer/reducer';
+import tuneContainerReducer from './containers/TuneContainer/reducer';
 
 /**
  * Merges the main reducer with the router state and dynamically injected reducers
@@ -17,7 +18,8 @@ export default function createReducer(injectedReducer = {}) {
     ...injectedReducer,
     language: languageProviderReducer,
     router: connectRouter(history),
-    homeContainer: homeContainerReducer
+    homeContainer: homeContainerReducer,
+    tuneContainer: tuneContainerReducer
   });
 
   return rootReducer;

--- a/app/routeConfig.js
+++ b/app/routeConfig.js
@@ -1,10 +1,15 @@
 import NotFound from '@containers/NotFoundPage/Loadable';
 import HomeContainer from '@containers/HomeContainer/Loadable';
 import routeConstants from '@utils/routeConstants';
+import TuneContainer from '@containers/TuneContainer/Loadable';
 export const routeConfig = {
   repos: {
     component: HomeContainer,
     ...routeConstants.repos
+  },
+  songs: {
+    component: TuneContainer,
+    ...routeConstants.songs
   },
   notFoundPage: {
     component: NotFound,

--- a/app/services/repoApi.js
+++ b/app/services/repoApi.js
@@ -1,4 +1,7 @@
 import { generateApiClient } from '@utils/apiUtils';
 const repoApi = generateApiClient('github');
 
+const songApi = generateApiClient('itunes');
+
 export const getRepos = (repoName) => repoApi.get(`/search/repositories?q=${repoName}`);
+export const getSongs = (searchTerm) => songApi.get(`/search?term=${searchTerm}`);

--- a/app/services/tests/repoApi.test.js
+++ b/app/services/tests/repoApi.test.js
@@ -1,6 +1,6 @@
 import MockAdapter from 'axios-mock-adapter';
 import { getApiClient } from '@utils/apiUtils';
-import { getRepos } from '../repoApi';
+import { getRepos, getSongs } from '../repoApi';
 
 describe('RepoApi tests', () => {
   const repositoryName = 'mac';
@@ -14,6 +14,22 @@ describe('RepoApi tests', () => {
     ];
     mock.onGet(`/search/repositories?q=${repositoryName}`).reply(200, data);
     const res = await getRepos(repositoryName);
+    expect(res.data).toEqual(data);
+  });
+});
+
+describe('SongApi tests', () => {
+  const searchTerm = 'Sia';
+  it('should make the api call to "/search?term="', async () => {
+    const mock = new MockAdapter(getApiClient('itunes').axiosInstance);
+    const data = [
+      {
+        resultsCount: 1,
+        results: [{ searchTerm }]
+      }
+    ];
+    mock.onGet(`/search?term=${searchTerm}`).reply(200, data);
+    const res = await getSongs(searchTerm);
     expect(res.data).toEqual(data);
   });
 });

--- a/app/utils/apiUtils.js
+++ b/app/utils/apiUtils.js
@@ -5,11 +5,15 @@ import { mapKeysDeep } from './index';
 
 const apiClients = {
   github: null,
-  default: null
+  default: null,
+  itunes: null
 };
 export const getApiClient = (type = 'github') => apiClients[type];
 export const generateApiClient = (type = 'github') => {
   switch (type) {
+    case 'itunes':
+      apiClients[type] = createApiClientWithTransForm(process.env.ITUNES_URL);
+      return apiClients[type];
     case 'github':
       apiClients[type] = createApiClientWithTransForm(process.env.GITHUB_URL);
       return apiClients[type];

--- a/app/utils/createintl.js
+++ b/app/utils/createintl.js
@@ -1,0 +1,12 @@
+import { createIntl, createIntlCache } from 'react-intl';
+import translations from '../translations/en.json';
+
+export default function getIntl() {
+  return createIntl(
+    {
+      locale: 'en',
+      messages: translations
+    },
+    createIntlCache()
+  );
+}

--- a/app/utils/routeConstants.js
+++ b/app/utils/routeConstants.js
@@ -6,5 +6,13 @@ export default {
       padding: 20
     },
     exact: true
+  },
+  songs: {
+    route: '/songs',
+    props: {
+      maxwidth: 500,
+      padding: 20
+    },
+    exact: true
   }
 };


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description
Generated TuneContainer to show data fetched from itunes api. Added tests and code for TuneContainer Saga, Reducer, & Api.
---

### Steps to Reproduce / Test

---
 * Go to localhost:3000/songs
 * Open the Redux Dev tool.
 * Type any song or artist name on the search bar, see the tuneContainer state change based on input and response .
### GIF's

---
![action](https://user-images.githubusercontent.com/89914287/132009663-cc76b5a8-c2fe-42d6-8e93-2abef78b1c48.gif)
![test](https://user-images.githubusercontent.com/89914287/132009734-6ea372eb-6edc-43b7-9590-e5f618cc74b6.gif)