### PR TITLE
Added TrackDetails Comp, related Features and Tests

### DIFF
--- a/app/components/TuneCard/index.js
+++ b/app/components/TuneCard/index.js
@@ -30,6 +30,7 @@ const IconButton = styled(Button)`
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
 `;
 
 const StyledT = styled(Title)`
@@ -42,7 +43,8 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
   const audioRef = useRef();
   const [play, setPlay] = useState(false);
 
-  const handlePlayPause = () => {
+  const handlePlayPause = (e) => {
+    e.preventDefault();
     const isPaused = audioRef.current.paused;
     if (isPaused) {
       audioRef.current.play();
@@ -56,33 +58,31 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
   };
 
   return (
-    <ItemCard maxwidth={maxwidth} data-testid="tune-card">
-      <StyledT fontSize={1.6} data-testid="artist-name">
-        {artistName}
-      </StyledT>
-      <If condition={songId} otherwise={<Image src={cardImg} width="100%" preview={false} />}>
-        <Link to={`/songs/${songId}`}>
-          <Image src={cardImg} width="100%" preview={false} />
-        </Link>
-      </If>
-      <StyledT fontSize={1.2}>{collectionName}</StyledT>
+    <Link to={`/details/${songId}`}>
+      <ItemCard maxwidth={maxwidth} data-testid="tune-card">
+        <StyledT fontSize={1.6} data-testid="artist-name">
+          {artistName}
+        </StyledT>
+        <Image src={cardImg} width="100%" preview={false} />
+        <StyledT fontSize={1.2}>{collectionName}</StyledT>
 
-      <IconButton
-        shape="circle"
-        type="text"
-        data-testid="play-pause-btn"
-        onClick={handlePlayPause}
-        icon={
-          <If
-            condition={!audioRef.current?.paused && audioRef.current?.src}
-            otherwise={<PlayCircleFilled style={iconStyle} />}
-          >
-            <PauseCircleFilled style={iconStyle} />
-          </If>
-        }
-      />
-      <audio ref={audioRef} data-testid="audio" src={previewUrl}></audio>
-    </ItemCard>
+        <IconButton
+          shape="circle"
+          type="text"
+          data-testid="play-pause-btn"
+          onClick={handlePlayPause}
+          icon={
+            <If
+              condition={!audioRef.current?.paused && audioRef.current?.src}
+              otherwise={<PlayCircleFilled style={iconStyle} />}
+            >
+              <PauseCircleFilled style={iconStyle} />
+            </If>
+          }
+        />
+        <audio ref={audioRef} data-testid="audio" src={previewUrl}></audio>
+      </ItemCard>
+    </Link>
   );
 }
 

--- a/app/components/TuneCard/index.js
+++ b/app/components/TuneCard/index.js
@@ -45,9 +45,9 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
 
   const handlePlayPause = (e, url) => {
     e.preventDefault();
-    audioRef.current.src = url;
     const isPaused = audioRef.current.paused;
     if (isPaused) {
+      audioRef.current.src = url;
       audioRef.current.play();
     } else {
       audioRef.current.pause();

--- a/app/components/TuneCard/index.js
+++ b/app/components/TuneCard/index.js
@@ -88,7 +88,6 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
       <Link to={`/songs/${songId}`} songId={songId}>
         {renderItemCard()}
       </Link>
-      ;
     </If>
   );
 }

--- a/app/components/TuneCard/index.js
+++ b/app/components/TuneCard/index.js
@@ -85,9 +85,7 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
 
   return (
     <If condition={songId} otherwise={renderItemCard()}>
-      <Link to={`/songs/${songId}`} songId={songId}>
-        {renderItemCard()}
-      </Link>
+      <Link to={`/${songId}`}>{renderItemCard()}</Link>
     </If>
   );
 }

--- a/app/components/TuneCard/index.js
+++ b/app/components/TuneCard/index.js
@@ -57,32 +57,39 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
     }
   };
 
-  return (
-    <Link to={`/details/${songId}`}>
-      <ItemCard maxwidth={maxwidth} data-testid="tune-card">
-        <StyledT fontSize={1.6} data-testid="artist-name">
-          {artistName}
-        </StyledT>
-        <Image src={cardImg} width="100%" preview={false} />
-        <StyledT fontSize={1.2}>{collectionName}</StyledT>
+  const renderItemCard = () => (
+    <ItemCard maxwidth={maxwidth} data-testid="tune-card">
+      <StyledT fontSize={1.6} data-testid="artist-name">
+        {artistName}
+      </StyledT>
+      <Image src={cardImg} width="100%" preview={false} />
+      <StyledT fontSize={1.2}>{collectionName}</StyledT>
 
-        <IconButton
-          shape="circle"
-          type="text"
-          data-testid="play-pause-btn"
-          onClick={handlePlayPause}
-          icon={
-            <If
-              condition={!audioRef.current?.paused && audioRef.current?.src}
-              otherwise={<PlayCircleFilled style={iconStyle} />}
-            >
-              <PauseCircleFilled style={iconStyle} />
-            </If>
-          }
-        />
-        <audio ref={audioRef} data-testid="audio" src={previewUrl}></audio>
-      </ItemCard>
-    </Link>
+      <IconButton
+        shape="circle"
+        type="text"
+        data-testid="play-pause-btn"
+        onClick={handlePlayPause}
+        icon={
+          <If
+            condition={!audioRef.current?.paused && audioRef.current?.src}
+            otherwise={<PlayCircleFilled style={iconStyle} />}
+          >
+            <PauseCircleFilled style={iconStyle} />
+          </If>
+        }
+      />
+      <audio ref={audioRef} data-testid="audio" src={previewUrl}></audio>
+    </ItemCard>
+  );
+
+  return (
+    <If condition={songId} otherwise={renderItemCard()}>
+      <Link to={`/songs/${songId}`} songId={songId}>
+        {renderItemCard()}
+      </Link>
+      ;
+    </If>
   );
 }
 

--- a/app/components/TuneCard/index.js
+++ b/app/components/TuneCard/index.js
@@ -7,7 +7,7 @@
 import React, { memo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Card, Typography, Image, Button } from 'antd';
+import { Card, Typography, Button, Row, Col } from 'antd';
 import { PlayCircleFilled, PauseCircleFilled } from '@ant-design/icons';
 import If from '@components/If';
 import { Link } from 'react-router-dom';
@@ -59,40 +59,50 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
   };
 
   const renderItemCard = () => (
-    <ItemCard maxwidth={maxwidth} data-testid="tune-card">
-      <StyledT fontSize={1.6} data-testid="artist-name">
-        {artistName}
-      </StyledT>
-      <Image src={cardImg} width="100%" preview={false} />
-      <StyledT fontSize={1.2}>{collectionName}</StyledT>
-
-      <IconButton
-        shape="circle"
-        type="text"
-        data-testid="play-pause-btn"
-        onClick={(e) => handlePlayPause(e, previewUrl)}
-        icon={
-          <If
-            condition={!audioRef.current?.paused && audioRef.current?.src}
-            otherwise={<PlayCircleFilled style={iconStyle} />}
-          >
-            <PauseCircleFilled style={iconStyle} />
-          </If>
-        }
-      />
+    <ItemCard maxwidth={maxwidth} data-testid="tune-card" cover={<img alt="example" src={cardImg} />}>
+      <Row>
+        <Col>
+          <StyledT fontSize={1.6} data-testid="artist-name">
+            {artistName}
+          </StyledT>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Card.Meta fontSize={1.2} title={collectionName} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <IconButton
+            shape="circle"
+            type="text"
+            data-testid="play-pause-btn"
+            onClick={(e) => handlePlayPause(e, previewUrl)}
+            icon={
+              <If
+                condition={!audioRef.current?.paused && audioRef.current?.src}
+                otherwise={<PlayCircleFilled style={iconStyle} />}
+              >
+                <PauseCircleFilled style={iconStyle} />
+              </If>
+            }
+          />
+        </Col>
+      </Row>
       <audio ref={audioRef} data-testid="audio"></audio>
     </ItemCard>
   );
 
   return (
     <If condition={songId} otherwise={renderItemCard()}>
-      <Link to={`/${songId}`}>{renderItemCard()}</Link>
+      <Link to={`/songs/${songId}`}>{renderItemCard()}</Link>
     </If>
   );
 }
 
 TuneCard.defaultProps = {
-  maxwidth: 300
+  maxwidth: 240
 };
 TuneCard.propTypes = {
   artistName: PropTypes.string,

--- a/app/components/TuneCard/index.js
+++ b/app/components/TuneCard/index.js
@@ -43,8 +43,9 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
   const audioRef = useRef();
   const [play, setPlay] = useState(false);
 
-  const handlePlayPause = (e) => {
+  const handlePlayPause = (e, url) => {
     e.preventDefault();
+    audioRef.current.src = url;
     const isPaused = audioRef.current.paused;
     if (isPaused) {
       audioRef.current.play();
@@ -69,7 +70,7 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
         shape="circle"
         type="text"
         data-testid="play-pause-btn"
-        onClick={handlePlayPause}
+        onClick={(e) => handlePlayPause(e, previewUrl)}
         icon={
           <If
             condition={!audioRef.current?.paused && audioRef.current?.src}
@@ -79,7 +80,7 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
           </If>
         }
       />
-      <audio ref={audioRef} data-testid="audio" src={previewUrl}></audio>
+      <audio ref={audioRef} data-testid="audio"></audio>
     </ItemCard>
   );
 

--- a/app/components/TuneCard/index.js
+++ b/app/components/TuneCard/index.js
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import { Card, Typography, Image, Button } from 'antd';
 import { PlayCircleFilled, PauseCircleFilled } from '@ant-design/icons';
 import If from '@components/If';
+import { Link } from 'react-router-dom';
 
 const { Title } = Typography;
 
@@ -33,11 +34,11 @@ const IconButton = styled(Button)`
 
 const StyledT = styled(Title)`
   && {
-    font-size: ${(props) => props.fontSize};
+    font-size: ${(props) => props.fontSize}em;
   }
 `;
 
-export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previewUrl, handleOnActionClick }) {
+export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previewUrl, handleOnActionClick, songId }) {
   const audioRef = useRef();
   const [play, setPlay] = useState(false);
 
@@ -49,16 +50,22 @@ export function TuneCard({ maxwidth, artistName, collectionName, cardImg, previe
       audioRef.current.pause();
     }
     setPlay(!play);
-    handleOnActionClick(audioRef);
+    if (handleOnActionClick) {
+      handleOnActionClick(audioRef);
+    }
   };
 
   return (
     <ItemCard maxwidth={maxwidth} data-testid="tune-card">
-      <StyledT fontSize={16} data-testid="artist-name">
+      <StyledT fontSize={1.6} data-testid="artist-name">
         {artistName}
       </StyledT>
-      <Image src={cardImg} width="100%" preview={false} />
-      <StyledT fontSize={18}>{collectionName}</StyledT>
+      <If condition={songId} otherwise={<Image src={cardImg} width="100%" preview={false} />}>
+        <Link to={`/songs/${songId}`}>
+          <Image src={cardImg} width="100%" preview={false} />
+        </Link>
+      </If>
+      <StyledT fontSize={1.2}>{collectionName}</StyledT>
 
       <IconButton
         shape="circle"
@@ -88,7 +95,8 @@ TuneCard.propTypes = {
   collectionName: PropTypes.string,
   cardImg: PropTypes.string,
   previewUrl: PropTypes.string,
-  handleOnActionClick: PropTypes.func
+  handleOnActionClick: PropTypes.func,
+  songId: PropTypes.string
 };
 
 export default memo(TuneCard);

--- a/app/components/TuneCard/index.js
+++ b/app/components/TuneCard/index.js
@@ -96,7 +96,7 @@ TuneCard.propTypes = {
   cardImg: PropTypes.string,
   previewUrl: PropTypes.string,
   handleOnActionClick: PropTypes.func,
-  songId: PropTypes.string
+  songId: PropTypes.number
 };
 
 export default memo(TuneCard);

--- a/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
+++ b/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
@@ -4,61 +4,92 @@ exports[`<TuneCard /> should render and match the snapshot 1`] = `
 <body>
   <div>
     <div
-      class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
+      class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 hjgfUg"
       data-testid="tune-card"
-      maxwidth="300"
+      maxwidth="240"
     >
+      <div
+        class="ant-card-cover"
+      >
+        <img
+          alt="example"
+          src="https://is4-ssl.mzstatic.com/image/thumb/Music115/v4/8d/af/2e/8daf2ed5-b5c1-9c53-17fc-a10d7a247121/source/100x100bb.jpg"
+        />
+      </div>
       <div
         class="ant-card-body"
       >
-        <h1
-          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
-          data-testid="artist-name"
-          font-size="1.6"
-        >
-          AlanWalker
-        </h1>
         <div
-          class="ant-image"
-          style="width: 100%;"
+          class="ant-row"
         >
-          <img
-            class="ant-image-img"
-            src="https://is4-ssl.mzstatic.com/image/thumb/Music115/v4/8d/af/2e/8daf2ed5-b5c1-9c53-17fc-a10d7a247121/source/100x100bb.jpg"
-          />
-        </div>
-        <h1
-          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
-          font-size="1.2"
-        >
-          Some Collection
-        </h1>
-        <button
-          class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
-          data-testid="play-pause-btn"
-          type="button"
-        >
-          <span
-            aria-label="play-circle"
-            class="anticon anticon-play-circle"
-            role="img"
-            style="font-size: 32px;"
+          <div
+            class="ant-col"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="play-circle"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
+            <h1
+              class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
+              data-testid="artist-name"
+              font-size="1.6"
             >
-              <path
-                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
-              />
-            </svg>
-          </span>
-        </button>
+              AlanWalker
+            </h1>
+          </div>
+        </div>
+        <div
+          class="ant-row"
+        >
+          <div
+            class="ant-col"
+          >
+            <div
+              class="ant-card-meta"
+              font-size="1.2"
+            >
+              <div
+                class="ant-card-meta-detail"
+              >
+                <div
+                  class="ant-card-meta-title"
+                >
+                  Some Collection
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-row"
+        >
+          <div
+            class="ant-col"
+          >
+            <button
+              class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
+              data-testid="play-pause-btn"
+              type="button"
+            >
+              <span
+                aria-label="play-circle"
+                class="anticon anticon-play-circle"
+                role="img"
+                style="font-size: 32px;"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="play-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
         <audio
           data-testid="audio"
         />

--- a/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
+++ b/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
@@ -3,72 +3,68 @@
 exports[`<TuneCard /> should render and match the snapshot 1`] = `
 <body>
   <div>
-    <a
-      href="/details/undefined"
+    <div
+      class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
+      data-testid="tune-card"
+      maxwidth="300"
     >
       <div
-        class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
-        data-testid="tune-card"
-        maxwidth="300"
+        class="ant-card-body"
       >
-        <div
-          class="ant-card-body"
+        <h1
+          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
+          data-testid="artist-name"
+          font-size="1.6"
         >
-          <h1
-            class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
-            data-testid="artist-name"
-            font-size="1.6"
-          >
-            AlanWalker
-          </h1>
-          <div
-            class="ant-image"
-            style="width: 100%;"
-          >
-            <img
-              class="ant-image-img"
-              src="https://is4-ssl.mzstatic.com/image/thumb/Music115/v4/8d/af/2e/8daf2ed5-b5c1-9c53-17fc-a10d7a247121/source/100x100bb.jpg"
-            />
-          </div>
-          <h1
-            class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
-            font-size="1.2"
-          >
-            Some Collection
-          </h1>
-          <button
-            class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
-            data-testid="play-pause-btn"
-            type="button"
-          >
-            <span
-              aria-label="play-circle"
-              class="anticon anticon-play-circle"
-              role="img"
-              style="font-size: 32px;"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="play-circle"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
-                />
-              </svg>
-            </span>
-          </button>
-          <audio
-            data-testid="audio"
-            src="https://abc.mp3/"
+          AlanWalker
+        </h1>
+        <div
+          class="ant-image"
+          style="width: 100%;"
+        >
+          <img
+            class="ant-image-img"
+            src="https://is4-ssl.mzstatic.com/image/thumb/Music115/v4/8d/af/2e/8daf2ed5-b5c1-9c53-17fc-a10d7a247121/source/100x100bb.jpg"
           />
         </div>
+        <h1
+          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
+          font-size="1.2"
+        >
+          Some Collection
+        </h1>
+        <button
+          class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
+          data-testid="play-pause-btn"
+          type="button"
+        >
+          <span
+            aria-label="play-circle"
+            class="anticon anticon-play-circle"
+            role="img"
+            style="font-size: 32px;"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="play-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+              />
+            </svg>
+          </span>
+        </button>
+        <audio
+          data-testid="audio"
+          src="https://abc.mp3/"
+        />
       </div>
-    </a>
+    </div>
   </div>
 </body>
 `;

--- a/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
+++ b/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
@@ -3,68 +3,72 @@
 exports[`<TuneCard /> should render and match the snapshot 1`] = `
 <body>
   <div>
-    <div
-      class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
-      data-testid="tune-card"
-      maxwidth="300"
+    <a
+      href="/details/undefined"
     >
       <div
-        class="ant-card-body"
+        class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
+        data-testid="tune-card"
+        maxwidth="300"
       >
-        <h1
-          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
-          data-testid="artist-name"
-          font-size="1.6"
-        >
-          AlanWalker
-        </h1>
         <div
-          class="ant-image"
-          style="width: 100%;"
+          class="ant-card-body"
         >
-          <img
-            class="ant-image-img"
-            src="https://is4-ssl.mzstatic.com/image/thumb/Music115/v4/8d/af/2e/8daf2ed5-b5c1-9c53-17fc-a10d7a247121/source/100x100bb.jpg"
+          <h1
+            class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
+            data-testid="artist-name"
+            font-size="1.6"
+          >
+            AlanWalker
+          </h1>
+          <div
+            class="ant-image"
+            style="width: 100%;"
+          >
+            <img
+              class="ant-image-img"
+              src="https://is4-ssl.mzstatic.com/image/thumb/Music115/v4/8d/af/2e/8daf2ed5-b5c1-9c53-17fc-a10d7a247121/source/100x100bb.jpg"
+            />
+          </div>
+          <h1
+            class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
+            font-size="1.2"
+          >
+            Some Collection
+          </h1>
+          <button
+            class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
+            data-testid="play-pause-btn"
+            type="button"
+          >
+            <span
+              aria-label="play-circle"
+              class="anticon anticon-play-circle"
+              role="img"
+              style="font-size: 32px;"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="play-circle"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+                />
+              </svg>
+            </span>
+          </button>
+          <audio
+            data-testid="audio"
+            src="https://abc.mp3/"
           />
         </div>
-        <h1
-          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
-          font-size="1.2"
-        >
-          Some Collection
-        </h1>
-        <button
-          class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eaTgBZ"
-          data-testid="play-pause-btn"
-          type="button"
-        >
-          <span
-            aria-label="play-circle"
-            class="anticon anticon-play-circle"
-            role="img"
-            style="font-size: 32px;"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="play-circle"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
-              />
-            </svg>
-          </span>
-        </button>
-        <audio
-          data-testid="audio"
-          src="https://abc.mp3/"
-        />
       </div>
-    </div>
+    </a>
   </div>
 </body>
 `;

--- a/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
+++ b/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
@@ -12,9 +12,9 @@ exports[`<TuneCard /> should render and match the snapshot 1`] = `
         class="ant-card-body"
       >
         <h1
-          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 FOrUM"
+          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
           data-testid="artist-name"
-          font-size="16"
+          font-size="1.6"
         >
           AlanWalker
         </h1>
@@ -28,8 +28,8 @@ exports[`<TuneCard /> should render and match the snapshot 1`] = `
           />
         </div>
         <h1
-          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 EPPJu"
-          font-size="18"
+          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
+          font-size="1.2"
         >
           Some Collection
         </h1>

--- a/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
+++ b/app/components/TuneCard/tests/__snapshots__/index.test.js.snap
@@ -61,7 +61,6 @@ exports[`<TuneCard /> should render and match the snapshot 1`] = `
         </button>
         <audio
           data-testid="audio"
-          src="https://abc.mp3/"
         />
       </div>
     </div>

--- a/app/components/TuneCard/tests/index.test.js
+++ b/app/components/TuneCard/tests/index.test.js
@@ -99,4 +99,16 @@ describe('<TuneCard />', () => {
     await timeout(500);
     expect(audio.paused).toBeTruthy();
   });
+
+  it('should call handlePausePlay but not handleOnActionClick when handleOnActionClick is not passed as prop', () => {
+    const handlePlayPauseSpy = jest.fn();
+    const { getByTestId } = renderWithIntl(<TuneCard previewUrl={previewUrl} />);
+
+    const playPauseButton = getByTestId('play-pause-btn');
+
+    fireEvent.click(playPauseButton, { onclick: handlePlayPauseSpy() });
+
+    expect(handlePlayPauseSpy).toBeCalled();
+    expect(handleOnActionClickSpy).not.toBeCalled();
+  });
 });

--- a/app/components/TuneCard/tests/index.test.js
+++ b/app/components/TuneCard/tests/index.test.js
@@ -38,8 +38,8 @@ describe('<TuneCard />', () => {
     expect(baseElement).toMatchSnapshot();
   });
 
-  it('should render and match artistName, collectionName, imgUrl', () => {
-    const { getByText, baseElement, getByTestId } = renderWithIntl(
+  it('should render and match artistName, collectionName', () => {
+    const { getByText, getByTestId } = renderWithIntl(
       <TuneCard
         artistName={artistName}
         collectionName={collectionName}
@@ -51,7 +51,6 @@ describe('<TuneCard />', () => {
 
     expect(getByTestId('artist-name').textContent).toEqual(artistName);
     expect(getByText(collectionName).textContent).toEqual(collectionName);
-    expect(baseElement.getElementsByClassName('ant-image-img')[0].src).toEqual(cardImg);
   });
 
   it('should call handlePlayPause && handleOnActionClick on Click', async () => {

--- a/app/containers/TuneContainer/TrackDetailContainer/Loadable.js
+++ b/app/containers/TuneContainer/TrackDetailContainer/Loadable.js
@@ -1,0 +1,3 @@
+import loadable from '@utils/loadable';
+
+export default loadable(() => import('./index'));

--- a/app/containers/TuneContainer/TrackDetailContainer/index.js
+++ b/app/containers/TuneContainer/TrackDetailContainer/index.js
@@ -16,15 +16,15 @@ import tuneContainerSaga from '../saga';
 import { useParams } from 'react-router';
 import { createStructuredSelector } from 'reselect';
 import styled from 'styled-components';
-import { Card } from 'antd';
+import { Card, Skeleton } from 'antd';
 import { TuneCard } from '@components/TuneCard';
 import If from '@components/If';
 import T from '@components/T';
-import { isEmpty } from 'lodash';
 
 const Container = styled.div`
   && {
     display: flex;
+    flex-direction: column;
     margin: 0 auto;
     padding: ${(props) => props.padding}em;
     min-height: ${(props) => props.minheight}em;
@@ -38,12 +38,14 @@ const CustomCard = styled(Card)`
     align-items: center;
     justify-content: center;
     padding: ${(props) => props.padding}em;
-    margin: ${(props) => props.margin};
     min-height: ${(props) => props.minheight}em;
     max-width: ${(props) => props.maxwidth}em;
+    border: 0;
   }
 `;
-
+const PlaceHolderDiv = styled.div`
+  min-width: 24em;
+`;
 function TrackDetailContainer({ dispatchGetTrackDetails, trackDetails, trackError }) {
   const { songId } = useParams();
 
@@ -53,34 +55,44 @@ function TrackDetailContainer({ dispatchGetTrackDetails, trackDetails, trackErro
 
   return (
     <Container minheight={40}>
-      <If condition={trackError && isEmpty(trackDetails)}>
-        <CustomCard data-testid="error-card">
-          <T data-testid="track-detail-error" id="something_went_wrong" />
-        </CustomCard>
-      </If>
-      <If condition={trackDetails && !trackError}>
-        <TuneCard
-          data-testid="tune-card"
-          artistName={trackDetails.artistName}
-          collectionName={trackDetails.collectionName}
-          previewUrl={trackDetails.previewUrl}
-          cardImg={trackDetails.artworkUrl100}
-        />
-      </If>
+      <CustomCard maxwidth={30}>
+        <PlaceHolderDiv></PlaceHolderDiv>
+        <Skeleton loading={!trackDetails && !trackError} active>
+          <If
+            condition={trackDetails && !trackError}
+            otherwise={
+              <CustomCard>
+                <T data-testid="track-detail-error" id="something_went_wrong" />
+              </CustomCard>
+            }
+          >
+            <TuneCard
+              key="hello-world"
+              data-testid="tune-card"
+              artistName={trackDetails?.artistName}
+              collectionName={trackDetails?.collectionName}
+              previewUrl={trackDetails?.previewUrl}
+              cardImg={trackDetails?.artworkUrl100}
+            />
+          </If>
+        </Skeleton>
+      </CustomCard>
     </Container>
   );
 }
 const mapStateToProps = createStructuredSelector({
   tuneContainer: selectTuneContainer(),
-  trackDetails: selectTrackDetails(),
-  trackError: selectTrackError()
+  trackError: selectTrackError(),
+  trackDetails: selectTrackDetails()
 });
+
 export function mapDispatchToProps(dispatch) {
   const { requestGetTrackDetails } = tuneContainerCreators;
   return {
     dispatchGetTrackDetails: (songId) => dispatch(requestGetTrackDetails(songId))
   };
 }
+
 const withConnect = connect(mapStateToProps, mapDispatchToProps);
 
 TrackDetailContainer.propTypes = {

--- a/app/containers/TuneContainer/TrackDetailContainer/index.js
+++ b/app/containers/TuneContainer/TrackDetailContainer/index.js
@@ -13,7 +13,7 @@ import { injectSaga } from 'redux-injectors';
 import { useParams } from 'react-router';
 import { createStructuredSelector } from 'reselect';
 import styled from 'styled-components';
-import { Card, Skeleton } from 'antd';
+import { Card, Skeleton, Row, Col, Typography } from 'antd';
 import { TuneCard } from '@components/TuneCard';
 import If from '@components/If';
 import T from '@components/T';
@@ -21,6 +21,7 @@ import { tuneContainerCreators } from '../reducer';
 import { selectTrackDetails, selectTrackError, selectTuneContainer } from '../selectors';
 import tuneContainerSaga from '../saga';
 
+const { Title } = Typography;
 const Container = styled.div`
   && {
     display: flex;
@@ -38,11 +39,30 @@ const CustomCard = styled(Card)`
     align-items: center;
     justify-content: center;
     padding: ${(props) => props.padding}em;
-    min-height: ${(props) => props.minheight}em;
+    height: 100%;
     max-width: ${(props) => props.maxwidth}em;
     border: 0;
   }
 `;
+
+const StyledTitle = styled(Title)`
+  && {
+    font-size: ${(props) => props.fontSize}em;
+    text-align: center;
+  }
+`;
+
+const StyledMeta = styled(Card.Meta)`
+  && {
+    text-align: center;
+  }
+`;
+const StyledRow = styled(Row)`
+  && {
+    justify-content: center;
+  }
+`;
+
 const PlaceHolderDiv = styled.div`
   min-width: 24em;
 `;
@@ -55,7 +75,7 @@ function TrackDetailContainer({ dispatchGetTrackDetails, trackDetails, trackErro
 
   return (
     <Container minheight={40}>
-      <CustomCard maxwidth={30}>
+      <CustomCard padding={1.4}>
         <PlaceHolderDiv></PlaceHolderDiv>
         <Skeleton loading={!trackDetails && !trackError} active>
           <If
@@ -66,13 +86,25 @@ function TrackDetailContainer({ dispatchGetTrackDetails, trackDetails, trackErro
               </CustomCard>
             }
           >
-            <TuneCard
-              data-testid="tune-card"
-              artistName={trackDetails?.artistName}
-              collectionName={trackDetails?.collectionName}
-              previewUrl={trackDetails?.previewUrl}
-              cardImg={trackDetails?.artworkUrl100}
-            />
+            <StyledRow gutter={[16, 24]}>
+              <Col>
+                <CustomCard maxwidth={30}>
+                  <StyledTitle fontSize={1.4}>Collection: {trackDetails?.collectionName}</StyledTitle>
+                  <StyledTitle fontSize={1.2}>Artist: {trackDetails?.artistName}</StyledTitle>
+                  <StyledMeta title={`Country: ${trackDetails?.country}`} />
+                  <StyledMeta title={`Genre name: ${trackDetails?.primaryGenreName}`} />
+                </CustomCard>
+              </Col>
+              <Col>
+                <StyledRow>
+                  <TuneCard
+                    cardImg={trackDetails?.artworkUrl100}
+                    artistName={trackDetails?.trackName}
+                    previewUrl={trackDetails?.previewUrl}
+                  />
+                </StyledRow>
+              </Col>
+            </StyledRow>
           </If>
         </Skeleton>
       </CustomCard>
@@ -100,7 +132,10 @@ TrackDetailContainer.propTypes = {
     artistName: PropTypes.string,
     collectionName: PropTypes.string,
     previewUrl: PropTypes.string,
-    artworkUrl100: PropTypes.string
+    artworkUrl100: PropTypes.string,
+    country: PropTypes.string,
+    primaryGenreName: PropTypes.string,
+    trackName: PropTypes.string
   }),
   trackError: PropTypes.string
 };

--- a/app/containers/TuneContainer/TrackDetailContainer/index.js
+++ b/app/containers/TuneContainer/TrackDetailContainer/index.js
@@ -9,10 +9,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
-import { tuneContainerCreators } from '../reducer';
-import { selectTrackDetails, selectTrackError, selectTuneContainer } from '../selectors';
 import { injectSaga } from 'redux-injectors';
-import tuneContainerSaga from '../saga';
 import { useParams } from 'react-router';
 import { createStructuredSelector } from 'reselect';
 import styled from 'styled-components';
@@ -20,6 +17,9 @@ import { Card, Skeleton } from 'antd';
 import { TuneCard } from '@components/TuneCard';
 import If from '@components/If';
 import T from '@components/T';
+import { tuneContainerCreators } from '../reducer';
+import { selectTrackDetails, selectTrackError, selectTuneContainer } from '../selectors';
+import tuneContainerSaga from '../saga';
 
 const Container = styled.div`
   && {
@@ -67,7 +67,6 @@ function TrackDetailContainer({ dispatchGetTrackDetails, trackDetails, trackErro
             }
           >
             <TuneCard
-              key="hello-world"
               data-testid="tune-card"
               artistName={trackDetails?.artistName}
               collectionName={trackDetails?.collectionName}

--- a/app/containers/TuneContainer/TrackDetailContainer/index.js
+++ b/app/containers/TuneContainer/TrackDetailContainer/index.js
@@ -1,0 +1,104 @@
+/**
+ *
+ * TrackDetailContainer
+ *
+ */
+
+import React, { memo, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
+import { tuneContainerCreators } from '../reducer';
+import { selectTrackDetails, selectTrackError, selectTuneContainer } from '../selectors';
+import { injectSaga } from 'redux-injectors';
+import tuneContainerSaga from '../saga';
+import { useParams } from 'react-router';
+import { createStructuredSelector } from 'reselect';
+import styled from 'styled-components';
+import { Card } from 'antd';
+import { TuneCard } from '@components/TuneCard';
+import If from '@components/If';
+import T from '@components/T';
+import { isEmpty } from 'lodash';
+
+const Container = styled.div`
+  && {
+    display: flex;
+    margin: 0 auto;
+    padding: ${(props) => props.padding}em;
+    min-height: ${(props) => props.minheight}em;
+    align-items: center;
+    justify-content: center;
+  }
+`;
+const CustomCard = styled(Card)`
+  && {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: ${(props) => props.padding}em;
+    margin: ${(props) => props.margin};
+    min-height: ${(props) => props.minheight}em;
+    max-width: ${(props) => props.maxwidth}em;
+  }
+`;
+
+function TrackDetailContainer({ dispatchGetTrackDetails, trackDetails, trackError }) {
+  const { songId } = useParams();
+
+  useEffect(() => {
+    dispatchGetTrackDetails(songId);
+  }, []);
+
+  return (
+    <Container minheight={40}>
+      <If condition={trackError && isEmpty(trackDetails)}>
+        <CustomCard data-testid="error-card">
+          <T data-testid="track-detail-error" id="something_went_wrong" />
+        </CustomCard>
+      </If>
+      <If condition={trackDetails && !trackError}>
+        <TuneCard
+          data-testid="tune-card"
+          artistName={trackDetails.artistName}
+          collectionName={trackDetails.collectionName}
+          previewUrl={trackDetails.previewUrl}
+          cardImg={trackDetails.artworkUrl100}
+        />
+      </If>
+    </Container>
+  );
+}
+const mapStateToProps = createStructuredSelector({
+  tuneContainer: selectTuneContainer(),
+  trackDetails: selectTrackDetails(),
+  trackError: selectTrackError()
+});
+export function mapDispatchToProps(dispatch) {
+  const { requestGetTrackDetails } = tuneContainerCreators;
+  return {
+    dispatchGetTrackDetails: (songId) => dispatch(requestGetTrackDetails(songId))
+  };
+}
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
+
+TrackDetailContainer.propTypes = {
+  dispatchGetTrackDetails: PropTypes.func,
+  trackDetails: PropTypes.shape({
+    artistName: PropTypes.string,
+    collectionName: PropTypes.string,
+    previewUrl: PropTypes.string,
+    artworkUrl100: PropTypes.string
+  }),
+  trackError: PropTypes.string
+};
+
+export default compose(
+  withConnect,
+  memo,
+  injectIntl,
+  injectSaga({ key: 'tuneContainer', saga: tuneContainerSaga })
+)(TrackDetailContainer);
+
+export const TrackDetailContainerTest = compose(injectIntl)(TrackDetailContainer);

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
@@ -7,54 +7,46 @@ exports[`<TrackDetailContainer /> should render and match the snapshot 1`] = `
       class="TrackDetailContainer__Container-sc-1jvorpq-0 kZtAhA"
     >
       <div
-        class="ant-card ant-card-bordered TrackDetailContainer__CustomCard-sc-1jvorpq-1 ijQmdK"
-        maxwidth="30"
+        class="ant-card ant-card-bordered TrackDetailContainer__CustomCard-sc-1jvorpq-1 iOzOIi"
+        padding="1.4"
       >
         <div
           class="ant-card-body"
         >
           <div
-            class="TrackDetailContainer__PlaceHolderDiv-sc-1jvorpq-2 hTFdUQ"
+            class="TrackDetailContainer__PlaceHolderDiv-sc-1jvorpq-5 OTynr"
           />
           <div
-            class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 hjgfUg"
-            data-testid="tune-card"
-            maxwidth="240"
+            class="ant-row TrackDetailContainer__StyledRow-sc-1jvorpq-4 dTDiEL"
+            style="margin: -12px -8px -12px -8px;"
           >
             <div
-              class="ant-card-cover"
-            >
-              <img
-                alt="example"
-              />
-            </div>
-            <div
-              class="ant-card-body"
+              class="ant-col"
+              style="padding: 12px 8px 12px 8px;"
             >
               <div
-                class="ant-row"
+                class="ant-card ant-card-bordered TrackDetailContainer__CustomCard-sc-1jvorpq-1 KEEre"
+                maxwidth="30"
               >
                 <div
-                  class="ant-col"
+                  class="ant-card-body"
                 >
                   <h1
-                    class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
-                    data-testid="artist-name"
-                    font-size="1.6"
+                    class="ant-typography TrackDetailContainer__StyledTitle-sc-1jvorpq-2 cYSwbi"
+                    font-size="1.4"
                   >
+                    Collection: 
+                    abc
+                  </h1>
+                  <h1
+                    class="ant-typography TrackDetailContainer__StyledTitle-sc-1jvorpq-2 dhGsbg"
+                    font-size="1.2"
+                  >
+                    Artist: 
                     Sia
                   </h1>
-                </div>
-              </div>
-              <div
-                class="ant-row"
-              >
-                <div
-                  class="ant-col"
-                >
                   <div
-                    class="ant-card-meta"
-                    font-size="1.2"
+                    class="ant-card-meta TrackDetailContainer__StyledMeta-sc-1jvorpq-3 eHyqvw"
                   >
                     <div
                       class="ant-card-meta-detail"
@@ -62,49 +54,115 @@ exports[`<TrackDetailContainer /> should render and match the snapshot 1`] = `
                       <div
                         class="ant-card-meta-title"
                       >
-                        abc
+                        Country: undefined
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-card-meta TrackDetailContainer__StyledMeta-sc-1jvorpq-3 eHyqvw"
+                  >
+                    <div
+                      class="ant-card-meta-detail"
+                    >
+                      <div
+                        class="ant-card-meta-title"
+                      >
+                        Genre name: undefined
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
+            </div>
+            <div
+              class="ant-col"
+              style="padding: 12px 8px 12px 8px;"
+            >
               <div
-                class="ant-row"
+                class="ant-row TrackDetailContainer__StyledRow-sc-1jvorpq-4 dTDiEL"
               >
                 <div
-                  class="ant-col"
+                  class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 hjgfUg"
+                  data-testid="tune-card"
+                  maxwidth="240"
                 >
-                  <button
-                    class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
-                    data-testid="play-pause-btn"
-                    type="button"
+                  <div
+                    class="ant-card-cover"
                   >
-                    <span
-                      aria-label="play-circle"
-                      class="anticon anticon-play-circle"
-                      role="img"
-                      style="font-size: 32px;"
+                    <img
+                      alt="example"
+                    />
+                  </div>
+                  <div
+                    class="ant-card-body"
+                  >
+                    <div
+                      class="ant-row"
                     >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="play-circle"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
+                      <div
+                        class="ant-col"
                       >
-                        <path
-                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+                        <h1
+                          class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
+                          data-testid="artist-name"
+                          font-size="1.6"
+                        >
+                          
+                        </h1>
+                      </div>
+                    </div>
+                    <div
+                      class="ant-row"
+                    >
+                      <div
+                        class="ant-col"
+                      >
+                        <div
+                          class="ant-card-meta"
+                          font-size="1.2"
                         />
-                      </svg>
-                    </span>
-                  </button>
+                      </div>
+                    </div>
+                    <div
+                      class="ant-row"
+                    >
+                      <div
+                        class="ant-col"
+                      >
+                        <button
+                          class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
+                          data-testid="play-pause-btn"
+                          type="button"
+                        >
+                          <span
+                            aria-label="play-circle"
+                            class="anticon anticon-play-circle"
+                            role="img"
+                            style="font-size: 32px;"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="play-circle"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                    <audio
+                      data-testid="audio"
+                    />
+                  </div>
                 </div>
               </div>
-              <audio
-                data-testid="audio"
-              />
             </div>
           </div>
         </div>

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
@@ -4,67 +4,79 @@ exports[`<TrackDetailContainer /> should render and match the snapshot 1`] = `
 <body>
   <div>
     <div
-      class="TrackDetailContainer__Container-sc-1jvorpq-0 cPMrKU"
+      class="TrackDetailContainer__Container-sc-1jvorpq-0 kZtAhA"
     >
       <div
-        class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
-        data-testid="tune-card"
-        maxwidth="300"
+        class="ant-card ant-card-bordered TrackDetailContainer__CustomCard-sc-1jvorpq-1 ijQmdK"
+        maxwidth="30"
       >
         <div
           class="ant-card-body"
         >
-          <h1
-            class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
-            data-testid="artist-name"
-            font-size="1.6"
-          >
-            Sia
-          </h1>
           <div
-            class="ant-image"
-            style="width: 100%;"
-          >
-            <img
-              class="ant-image-img"
-            />
-          </div>
-          <h1
-            class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
-            font-size="1.2"
-          >
-            abc
-          </h1>
-          <button
-            class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eaTgBZ"
-            data-testid="play-pause-btn"
-            type="button"
-          >
-            <span
-              aria-label="play-circle"
-              class="anticon anticon-play-circle"
-              role="img"
-              style="font-size: 32px;"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="play-circle"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
-                />
-              </svg>
-            </span>
-          </button>
-          <audio
-            data-testid="audio"
-            src="https://bcw.mp3"
+            class="TrackDetailContainer__PlaceHolderDiv-sc-1jvorpq-2 hTFdUQ"
           />
+          <div
+            class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
+            data-testid="tune-card"
+            maxwidth="300"
+          >
+            <div
+              class="ant-card-body"
+            >
+              <h1
+                class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
+                data-testid="artist-name"
+                font-size="1.6"
+              >
+                Sia
+              </h1>
+              <div
+                class="ant-image"
+                style="width: 100%;"
+              >
+                <img
+                  class="ant-image-img"
+                />
+              </div>
+              <h1
+                class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
+                font-size="1.2"
+              >
+                abc
+              </h1>
+              <button
+                class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eaTgBZ"
+                data-testid="play-pause-btn"
+                type="button"
+              >
+                <span
+                  aria-label="play-circle"
+                  class="anticon anticon-play-circle"
+                  role="img"
+                  style="font-size: 32px;"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="play-circle"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <audio
+                data-testid="audio"
+                src="https://bcw.mp3"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TrackDetailContainer /> should render and match the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="TrackDetailContainer__Container-sc-1jvorpq-0 cPMrKU"
+    >
+      <div
+        class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
+        data-testid="tune-card"
+        maxwidth="300"
+      >
+        <div
+          class="ant-card-body"
+        >
+          <h1
+            class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
+            data-testid="artist-name"
+            font-size="1.6"
+          >
+            Sia
+          </h1>
+          <div
+            class="ant-image"
+            style="width: 100%;"
+          >
+            <img
+              class="ant-image-img"
+            />
+          </div>
+          <h1
+            class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
+            font-size="1.2"
+          >
+            abc
+          </h1>
+          <button
+            class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eaTgBZ"
+            data-testid="play-pause-btn"
+            type="button"
+          >
+            <span
+              aria-label="play-circle"
+              class="anticon anticon-play-circle"
+              role="img"
+              style="font-size: 32px;"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="play-circle"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+                />
+              </svg>
+            </span>
+          </button>
+          <audio
+            data-testid="audio"
+            src="https://bcw.mp3"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
@@ -16,67 +16,71 @@ exports[`<TrackDetailContainer /> should render and match the snapshot 1`] = `
           <div
             class="TrackDetailContainer__PlaceHolderDiv-sc-1jvorpq-2 hTFdUQ"
           />
-          <div
-            class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
-            data-testid="tune-card"
-            maxwidth="300"
+          <a
+            href="/details/undefined"
           >
             <div
-              class="ant-card-body"
+              class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
+              data-testid="tune-card"
+              maxwidth="300"
             >
-              <h1
-                class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
-                data-testid="artist-name"
-                font-size="1.6"
-              >
-                Sia
-              </h1>
               <div
-                class="ant-image"
-                style="width: 100%;"
+                class="ant-card-body"
               >
-                <img
-                  class="ant-image-img"
+                <h1
+                  class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
+                  data-testid="artist-name"
+                  font-size="1.6"
+                >
+                  Sia
+                </h1>
+                <div
+                  class="ant-image"
+                  style="width: 100%;"
+                >
+                  <img
+                    class="ant-image-img"
+                  />
+                </div>
+                <h1
+                  class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
+                  font-size="1.2"
+                >
+                  abc
+                </h1>
+                <button
+                  class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
+                  data-testid="play-pause-btn"
+                  type="button"
+                >
+                  <span
+                    aria-label="play-circle"
+                    class="anticon anticon-play-circle"
+                    role="img"
+                    style="font-size: 32px;"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="play-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <audio
+                  data-testid="audio"
+                  src="https://bcw.mp3"
                 />
               </div>
-              <h1
-                class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
-                font-size="1.2"
-              >
-                abc
-              </h1>
-              <button
-                class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eaTgBZ"
-                data-testid="play-pause-btn"
-                type="button"
-              >
-                <span
-                  aria-label="play-circle"
-                  class="anticon anticon-play-circle"
-                  role="img"
-                  style="font-size: 32px;"
-                >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="play-circle"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <audio
-                data-testid="audio"
-                src="https://bcw.mp3"
-              />
             </div>
-          </div>
+          </a>
         </div>
       </div>
     </div>

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
@@ -16,71 +16,67 @@ exports[`<TrackDetailContainer /> should render and match the snapshot 1`] = `
           <div
             class="TrackDetailContainer__PlaceHolderDiv-sc-1jvorpq-2 hTFdUQ"
           />
-          <a
-            href="/details/undefined"
+          <div
+            class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
+            data-testid="tune-card"
+            maxwidth="300"
           >
             <div
-              class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
-              data-testid="tune-card"
-              maxwidth="300"
+              class="ant-card-body"
             >
-              <div
-                class="ant-card-body"
+              <h1
+                class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
+                data-testid="artist-name"
+                font-size="1.6"
               >
-                <h1
-                  class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
-                  data-testid="artist-name"
-                  font-size="1.6"
-                >
-                  Sia
-                </h1>
-                <div
-                  class="ant-image"
-                  style="width: 100%;"
-                >
-                  <img
-                    class="ant-image-img"
-                  />
-                </div>
-                <h1
-                  class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
-                  font-size="1.2"
-                >
-                  abc
-                </h1>
-                <button
-                  class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
-                  data-testid="play-pause-btn"
-                  type="button"
-                >
-                  <span
-                    aria-label="play-circle"
-                    class="anticon anticon-play-circle"
-                    role="img"
-                    style="font-size: 32px;"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="play-circle"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <audio
-                  data-testid="audio"
-                  src="https://bcw.mp3"
+                Sia
+              </h1>
+              <div
+                class="ant-image"
+                style="width: 100%;"
+              >
+                <img
+                  class="ant-image-img"
                 />
               </div>
+              <h1
+                class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
+                font-size="1.2"
+              >
+                abc
+              </h1>
+              <button
+                class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
+                data-testid="play-pause-btn"
+                type="button"
+              >
+                <span
+                  aria-label="play-circle"
+                  class="anticon anticon-play-circle"
+                  role="img"
+                  style="font-size: 32px;"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="play-circle"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <audio
+                data-testid="audio"
+                src="https://bcw.mp3"
+              />
             </div>
-          </a>
+          </div>
         </div>
       </div>
     </div>

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
@@ -73,7 +73,6 @@ exports[`<TrackDetailContainer /> should render and match the snapshot 1`] = `
               </button>
               <audio
                 data-testid="audio"
-                src="https://bcw.mp3"
               />
             </div>
           </div>

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/__snapshots__/index.test.js.snap
@@ -17,60 +17,91 @@ exports[`<TrackDetailContainer /> should render and match the snapshot 1`] = `
             class="TrackDetailContainer__PlaceHolderDiv-sc-1jvorpq-2 hTFdUQ"
           />
           <div
-            class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 dBepYt"
+            class="ant-card ant-card-bordered TuneCard__ItemCard-sc-1cl6pnu-0 hjgfUg"
             data-testid="tune-card"
-            maxwidth="300"
+            maxwidth="240"
           >
+            <div
+              class="ant-card-cover"
+            >
+              <img
+                alt="example"
+              />
+            </div>
             <div
               class="ant-card-body"
             >
-              <h1
-                class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
-                data-testid="artist-name"
-                font-size="1.6"
-              >
-                Sia
-              </h1>
               <div
-                class="ant-image"
-                style="width: 100%;"
+                class="ant-row"
               >
-                <img
-                  class="ant-image-img"
-                />
-              </div>
-              <h1
-                class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 hVdOjy"
-                font-size="1.2"
-              >
-                abc
-              </h1>
-              <button
-                class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
-                data-testid="play-pause-btn"
-                type="button"
-              >
-                <span
-                  aria-label="play-circle"
-                  class="anticon anticon-play-circle"
-                  role="img"
-                  style="font-size: 32px;"
+                <div
+                  class="ant-col"
                 >
-                  <svg
-                    aria-hidden="true"
-                    data-icon="play-circle"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
+                  <h1
+                    class="ant-typography TuneCard__StyledT-sc-1cl6pnu-2 eJcBSi"
+                    data-testid="artist-name"
+                    font-size="1.6"
                   >
-                    <path
-                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
-                    />
-                  </svg>
-                </span>
-              </button>
+                    Sia
+                  </h1>
+                </div>
+              </div>
+              <div
+                class="ant-row"
+              >
+                <div
+                  class="ant-col"
+                >
+                  <div
+                    class="ant-card-meta"
+                    font-size="1.2"
+                  >
+                    <div
+                      class="ant-card-meta-detail"
+                    >
+                      <div
+                        class="ant-card-meta-title"
+                      >
+                        abc
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-row"
+              >
+                <div
+                  class="ant-col"
+                >
+                  <button
+                    class="ant-btn ant-btn-text ant-btn-circle ant-btn-icon-only TuneCard__IconButton-sc-1cl6pnu-1 eahDeJ"
+                    data-testid="play-pause-btn"
+                    type="button"
+                  >
+                    <span
+                      aria-label="play-circle"
+                      class="anticon anticon-play-circle"
+                      role="img"
+                      style="font-size: 32px;"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="play-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+              </div>
               <audio
                 data-testid="audio"
               />

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/index.test.js
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/index.test.js
@@ -1,0 +1,72 @@
+/**
+ *
+ * Tests for TrackDetailContainer
+ *
+ */
+
+import React from 'react';
+// import { fireEvent } from '@testing-library/dom'
+import { renderWithIntl, timeout } from '@utils/testUtils';
+import { mapDispatchToProps, TrackDetailContainerTest as TrackDetailContainer } from '../index';
+import { tuneContainerTypes } from '../../reducer';
+
+describe('<TrackDetailContainer />', () => {
+  let submitSpy;
+  let trackDetails;
+  beforeEach(() => {
+    trackDetails = {
+      artistName: 'Sia',
+      collectionName: 'abc',
+      cardImg: 'https://abc.jpg',
+      previewUrl: 'https://bcw.mp3',
+      trackId: '122'
+    };
+    submitSpy = jest.fn();
+  });
+
+  it('should render and match the snapshot', () => {
+    const { baseElement } = renderWithIntl(
+      <TrackDetailContainer trackDetails={trackDetails} dispatchGetTrackDetails={submitSpy} />
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should render Errorcard when trackError is true ', () => {
+    const error = 'something_went_wrong';
+    trackDetails = {};
+    const { getByTestId } = renderWithIntl(
+      <TrackDetailContainer dispatchGetTrackDetails={submitSpy} trackError={error} trackDetails={trackDetails} />
+    );
+    expect(getByTestId('error-card')).toBeInTheDocument();
+  });
+
+  it('should render TuneCard trackDetails is not empty', () => {
+    const { getByTestId } = renderWithIntl(
+      <TrackDetailContainer dispatchGetTrackDetails={submitSpy} trackDetails={trackDetails} />
+    );
+    expect(getByTestId('tune-card')).toBeInTheDocument();
+  });
+
+  it('should dispatch when FETCH_TRACK_DETAILS on mount', async () => {
+    trackDetails = {};
+    renderWithIntl(<TrackDetailContainer dispatchGetTrackDetails={submitSpy} trackDetails={trackDetails} />);
+
+    await timeout(500);
+    expect(submitSpy).toBeCalled();
+  });
+
+  it('should match mapDispatchToProps actions', async () => {
+    const songId = '345776';
+    const dispatchSpy = jest.fn((fn) => fn);
+    const dispatchGetTrackDetailsSpy = jest.fn(() => ({ type: tuneContainerTypes.REQUEST_GET_TRACK_DETAILS, songId }));
+
+    const props = mapDispatchToProps(dispatchSpy);
+
+    const actions = {
+      dispatchGetTrackDetailsSpy
+    };
+
+    props.dispatchGetTrackDetails(songId);
+    expect(dispatchSpy).toHaveBeenCalledWith(actions.dispatchGetTrackDetailsSpy());
+  });
+});

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/index.test.js
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/index.test.js
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-// import { fireEvent } from '@testing-library/dom'
 import { renderWithIntl, timeout } from '@utils/testUtils';
 import { mapDispatchToProps, TrackDetailContainerTest as TrackDetailContainer } from '../index';
 import { tuneContainerTypes } from '../../reducer';
@@ -40,14 +39,14 @@ describe('<TrackDetailContainer />', () => {
     expect(getByTestId('track-detail-error')).toBeInTheDocument();
   });
 
-  it('should render TuneCard trackDetails is not empty', () => {
+  it('should render TuneCard when trackDetails is not empty', () => {
     const { getByTestId } = renderWithIntl(
       <TrackDetailContainer dispatchGetTrackDetails={submitSpy} trackDetails={trackDetails} />
     );
     expect(getByTestId('tune-card')).toBeInTheDocument();
   });
 
-  it('should dispatch when FETCH_TRACK_DETAILS on mount', async () => {
+  it('should dispatch FETCH_TRACK_DETAILS on mount', async () => {
     renderWithIntl(<TrackDetailContainer dispatchGetTrackDetails={submitSpy} />);
 
     await timeout(500);

--- a/app/containers/TuneContainer/TrackDetailContainer/tests/index.test.js
+++ b/app/containers/TuneContainer/TrackDetailContainer/tests/index.test.js
@@ -33,11 +33,11 @@ describe('<TrackDetailContainer />', () => {
 
   it('should render Errorcard when trackError is true ', () => {
     const error = 'something_went_wrong';
-    trackDetails = {};
+
     const { getByTestId } = renderWithIntl(
-      <TrackDetailContainer dispatchGetTrackDetails={submitSpy} trackError={error} trackDetails={trackDetails} />
+      <TrackDetailContainer dispatchGetTrackDetails={submitSpy} trackError={error} />
     );
-    expect(getByTestId('error-card')).toBeInTheDocument();
+    expect(getByTestId('track-detail-error')).toBeInTheDocument();
   });
 
   it('should render TuneCard trackDetails is not empty', () => {
@@ -48,8 +48,7 @@ describe('<TrackDetailContainer />', () => {
   });
 
   it('should dispatch when FETCH_TRACK_DETAILS on mount', async () => {
-    trackDetails = {};
-    renderWithIntl(<TrackDetailContainer dispatchGetTrackDetails={submitSpy} trackDetails={trackDetails} />);
+    renderWithIntl(<TrackDetailContainer dispatchGetTrackDetails={submitSpy} />);
 
     await timeout(500);
     expect(submitSpy).toBeCalled();

--- a/app/containers/TuneContainer/index.js
+++ b/app/containers/TuneContainer/index.js
@@ -124,6 +124,7 @@ export function TuneContainer({
                   collectionName={result.collectionName}
                   cardImg={result.artworkUrl100}
                   previewUrl={result.previewUrl}
+                  songId={result.trackId}
                 />
               )}
             />

--- a/app/containers/TuneContainer/index.js
+++ b/app/containers/TuneContainer/index.js
@@ -10,9 +10,6 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { createStructuredSelector } from 'reselect';
 import { compose } from 'redux';
-import selectTuneContainer, { selectSearchTerm, selectSongsData, selectSongsError } from './selectors';
-import { tuneContainerCreators } from './reducer';
-import tuneContainerSaga from './saga';
 import { injectSaga } from 'redux-injectors';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
@@ -23,6 +20,9 @@ import T from '@components/T';
 import { TuneCard } from '@components/TuneCard';
 import For from '@components/For';
 import If from '@app/components/If';
+import selectTuneContainer, { selectSearchTerm, selectSongsData, selectSongsError } from './selectors';
+import { tuneContainerCreators } from './reducer';
+import tuneContainerSaga from './saga';
 
 const { Search } = Input;
 

--- a/app/containers/TuneContainer/reducer.js
+++ b/app/containers/TuneContainer/reducer.js
@@ -3,18 +3,28 @@
  * TuneContainer reducer
  *
  */
-import { translate } from '@app/components/IntlGlobalProvider/index';
+
 import produce from 'immer';
-import get from 'lodash/get';
 import { createActions } from 'reduxsauce';
 
-export const initialState = { searchTerm: null, songsData: [], songsError: null };
+export const initialState = {
+  searchTerm: null,
+  songsData: [],
+  songsError: null,
+  songId: null,
+  trackDetails: {},
+  trackError: null,
+  tracksCache: {}
+};
 
 export const { Types: tuneContainerTypes, Creators: tuneContainerCreators } = createActions({
   requestGetItuneSongs: ['searchTerm'],
   successGetItuneSongs: ['data'],
   failureGetItuneSongs: ['error'],
-  clearItuneSongs: []
+  clearItuneSongs: [],
+  requestGetTrackDetails: ['songId'],
+  successGetTrackDetails: ['data'],
+  failureGetTrackDetails: ['error']
 });
 
 /* eslint-disable default-case, no-param-reassign */
@@ -29,8 +39,20 @@ export const tuneContainerReducer = (state = initialState, action) =>
         draft.songsError = null;
         break;
       case tuneContainerTypes.FAILURE_GET_ITUNE_SONGS:
-        draft.songsError = get(action.error, 'message', translate('something_went_wrong'));
+        draft.songsError = action.error;
         draft.songsData = [];
+        break;
+      case tuneContainerTypes.REQUEST_GET_TRACK_DETAILS:
+        draft.songId = action.songId;
+        break;
+      case tuneContainerTypes.SUCCESS_GET_TRACK_DETAILS:
+        draft.trackError = null;
+        draft.tracksCache[draft.songId] = action.data;
+        draft.trackDetails = action.data;
+        break;
+      case tuneContainerTypes.FAILURE_GET_TRACK_DETAILS:
+        draft.trackDetails = {};
+        draft.trackError = action.error;
         break;
       case tuneContainerTypes.CLEAR_ITUNE_SONGS:
         return initialState;

--- a/app/containers/TuneContainer/reducer.js
+++ b/app/containers/TuneContainer/reducer.js
@@ -12,9 +12,8 @@ export const initialState = {
   songsData: [],
   songsError: null,
   songId: null,
-  trackDetails: {},
   trackError: null,
-  tracksCache: {}
+  trackDetails: null
 };
 
 export const { Types: tuneContainerTypes, Creators: tuneContainerCreators } = createActions({
@@ -43,15 +42,15 @@ export const tuneContainerReducer = (state = initialState, action) =>
         draft.songsData = [];
         break;
       case tuneContainerTypes.REQUEST_GET_TRACK_DETAILS:
+        draft.trackDetails = null;
+        draft.trackError = null;
         draft.songId = action.songId;
         break;
       case tuneContainerTypes.SUCCESS_GET_TRACK_DETAILS:
         draft.trackError = null;
-        draft.tracksCache[draft.songId] = action.data;
         draft.trackDetails = action.data;
         break;
       case tuneContainerTypes.FAILURE_GET_TRACK_DETAILS:
-        draft.trackDetails = {};
         draft.trackError = action.error;
         break;
       case tuneContainerTypes.CLEAR_ITUNE_SONGS:

--- a/app/containers/TuneContainer/saga.js
+++ b/app/containers/TuneContainer/saga.js
@@ -22,8 +22,8 @@ export function* getItuneSongs(action) {
 
 export function* getTrackDetails(action) {
   let songsData;
-  if (action.testSongData) {
-    songsData = action.testSongData;
+  if (action.songsDataCache) {
+    songsData = action.songsDataCache;
   } else {
     songsData = yield select(selectSongsData());
   }

--- a/app/containers/TuneContainer/saga.js
+++ b/app/containers/TuneContainer/saga.js
@@ -1,9 +1,12 @@
-import { getSongs } from '@app/services/repoApi';
-import { takeLatest, call, put } from 'redux-saga/effects';
+import { translate } from '@components/IntlGlobalProvider';
+import { getSongs, getSongDetails } from '@services/repoApi';
+import { takeLatest, call, put, select } from 'redux-saga/effects';
 import { tuneContainerCreators, tuneContainerTypes } from './reducer';
+import { selectTracksCache } from './selectors';
 // Individual exports for testing
-const { REQUEST_GET_ITUNE_SONGS } = tuneContainerTypes;
-const { successGetItuneSongs, failureGetItuneSongs } = tuneContainerCreators;
+const { REQUEST_GET_ITUNE_SONGS, REQUEST_GET_TRACK_DETAILS } = tuneContainerTypes;
+const { successGetItuneSongs, failureGetItuneSongs, successGetTrackDetails, failureGetTrackDetails } =
+  tuneContainerCreators;
 
 export function* getItuneSongs(action) {
   const response = yield call(getSongs, action.searchTerm);
@@ -12,10 +15,37 @@ export function* getItuneSongs(action) {
   if (ok) {
     yield put(successGetItuneSongs(data));
   } else {
-    yield put(failureGetItuneSongs(data));
+    const error = data?.originalError?.message ?? translate('something_went_wrong');
+    yield put(failureGetItuneSongs(error));
   }
 }
 
+export function* getTrackDetails(action) {
+  let songsCache;
+
+  if (action.testSagaCache) {
+    songsCache = action.testSagaCache;
+  } else {
+    songsCache = yield select(selectTracksCache());
+  }
+
+  if (songsCache && !songsCache[action.songId]) {
+    const response = yield call(getSongDetails, action.songId);
+    const { ok, data } = response;
+
+    if (ok && data.results.length !== 0) {
+      const _data = { ...data.results[0] };
+      yield put(successGetTrackDetails(_data));
+    } else {
+      const error = data?.originalError?.message ?? translate('something_went_wrong');
+      yield put(failureGetTrackDetails(error));
+    }
+  } else {
+    const data = { ...songsCache[action.songId] };
+    yield put(successGetTrackDetails(data));
+  }
+}
 export default function* tuneContainerSaga() {
   yield takeLatest(REQUEST_GET_ITUNE_SONGS, getItuneSongs);
+  yield takeLatest(REQUEST_GET_TRACK_DETAILS, getTrackDetails);
 }

--- a/app/containers/TuneContainer/saga.js
+++ b/app/containers/TuneContainer/saga.js
@@ -22,18 +22,18 @@ export function* getItuneSongs(action) {
 
 export function* getTrackDetails(action) {
   let songsData;
-  if (action.testData) {
-    songsData = action.testData;
+  if (action.testSongData) {
+    songsData = action.testSongData;
   } else {
     songsData = yield select(selectSongsData());
   }
 
-  const songItem = songsData?.results?.find((_song) => _song.trackId?.toString() === action.songId);
+  const songItem = songsData?.results?.find((song) => song.trackId?.toString() === action.songId);
 
   if (!songItem) {
     const response = yield call(getSongDetails, action.songId);
     const { ok, data } = response;
-    if (ok && data.results.length !== 0) {
+    if (ok && data.results.length) {
       yield put(successGetTrackDetails(data.results[0]));
     } else {
       const error = data?.originalError?.message ?? translate('something_went_wrong');

--- a/app/containers/TuneContainer/selectors.js
+++ b/app/containers/TuneContainer/selectors.js
@@ -18,4 +18,15 @@ export const selectSongsError = () =>
 export const selectSearchTerm = () =>
   createSelector(selectTuneContainerDomain, (substate) => get(substate, 'searchTerm', null));
 
+export const selectSongId = () => createSelector(selectTuneContainerDomain, (substate) => get(substate, 'songId'));
+
+export const selectTracksCache = () =>
+  createSelector(selectTuneContainerDomain, (substate) => get(substate, 'tracksCache'));
+
+export const selectTrackDetails = () =>
+  createSelector(selectTuneContainerDomain, (substate) => get(substate, 'trackDetails'));
+
+export const selectTrackError = () =>
+  createSelector(selectTuneContainerDomain, (substate) => get(substate, 'trackError'));
+
 export default selectTuneContainer;

--- a/app/containers/TuneContainer/selectors.js
+++ b/app/containers/TuneContainer/selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { initialState } from './reducer';
 import get from 'lodash/get';
+
 /**
  * Direct selector to the tuneContainer state domain
  */
@@ -19,9 +20,6 @@ export const selectSearchTerm = () =>
   createSelector(selectTuneContainerDomain, (substate) => get(substate, 'searchTerm', null));
 
 export const selectSongId = () => createSelector(selectTuneContainerDomain, (substate) => get(substate, 'songId'));
-
-export const selectTracksCache = () =>
-  createSelector(selectTuneContainerDomain, (substate) => get(substate, 'tracksCache'));
 
 export const selectTrackDetails = () =>
   createSelector(selectTuneContainerDomain, (substate) => get(substate, 'trackDetails'));

--- a/app/containers/TuneContainer/tests/index.test.js
+++ b/app/containers/TuneContainer/tests/index.test.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { renderProvider, timeout } from '@utils/testUtils';
+import { renderProvider, timeout, renderWithIntl } from '@utils/testUtils';
 import { fireEvent } from '@testing-library/dom';
 import { mapDispatchToProps, TuneContainerTest as TuneContainer } from '../index';
 import { tuneContainerTypes } from '../reducer';
@@ -34,7 +34,7 @@ describe('<TuneContainer /> container tests', () => {
         { id: 2, name: 'Some another data' }
       ]
     };
-    const { getByTestId } = renderProvider(<TuneContainer songsData={data} />);
+    const { getByTestId } = renderWithIntl(<TuneContainer songsData={data} />);
     expect(getByTestId('for')).toBeInTheDocument();
   });
 
@@ -52,7 +52,7 @@ describe('<TuneContainer /> container tests', () => {
         { id: 2, name: 'Some another data' }
       ]
     };
-    const { getAllByTestId } = renderProvider(<TuneContainer songsData={data} />);
+    const { getAllByTestId } = renderWithIntl(<TuneContainer songsData={data} />);
     expect(getAllByTestId('tune-card').length).toBe(2);
   });
   it('should render Skeleton Comp when "loading" is true', async () => {
@@ -152,7 +152,7 @@ describe('<TuneContainer /> container tests', () => {
       current.paused = !elem.paused;
     });
 
-    const { getAllByTestId } = renderProvider(<TuneContainer songsData={data} />);
+    const { getAllByTestId } = renderWithIntl(<TuneContainer songsData={data} />);
 
     const buttons = getAllByTestId('play-pause-btn');
     audios[0] = getAllByTestId('audio')[0];

--- a/app/containers/TuneContainer/tests/index.test.js
+++ b/app/containers/TuneContainer/tests/index.test.js
@@ -145,7 +145,7 @@ describe('<TuneContainer /> container tests', () => {
     let current;
 
     const handleOnActionClickSpy = jest.fn((elem) => {
-      if (current && current?.src !== elem.src) {
+      if (current && current?.paused !== elem.paused) {
         current.paused = true;
       }
       current = elem;

--- a/app/containers/TuneContainer/tests/reducer.test.js
+++ b/app/containers/TuneContainer/tests/reducer.test.js
@@ -75,9 +75,8 @@ describe('TuneContainer reducer tests', () => {
   it('should ensure that the trackDetails is present when FETCH_TRACK_DETAILS_SUCCESS is dispatched', () => {
     const songId = '12212';
     const data = { name: 'Sia' };
-    const tracksCache = { [songId]: data };
     state = { ...state, songId };
-    const expectedResult = { ...state, trackDetails: data, tracksCache };
+    const expectedResult = { ...state, trackDetails: data };
 
     expect(
       tuneContainerReducer(state, {

--- a/app/containers/TuneContainer/tests/reducer.test.js
+++ b/app/containers/TuneContainer/tests/reducer.test.js
@@ -59,4 +59,44 @@ describe('TuneContainer reducer tests', () => {
       })
     ).toEqual(expectedResult);
   });
+
+  it('should return the state when an action of type FETCH_TRACK_DETAILS is dispatched', () => {
+    const songId = '918556408';
+    const expectedResult = { ...state, songId };
+
+    expect(
+      tuneContainerReducer(state, {
+        type: tuneContainerTypes.REQUEST_GET_TRACK_DETAILS,
+        songId
+      })
+    ).toEqual(expectedResult);
+  });
+
+  it('should ensure that the trackDetails is present when FETCH_TRACK_DETAILS_SUCCESS is dispatched', () => {
+    const songId = '12212';
+    const data = { name: 'Sia' };
+    const tracksCache = { [songId]: data };
+    state = { ...state, songId };
+    const expectedResult = { ...state, trackDetails: data, tracksCache };
+
+    expect(
+      tuneContainerReducer(state, {
+        type: tuneContainerTypes.SUCCESS_GET_TRACK_DETAILS,
+        data
+      })
+    ).toEqual(expectedResult);
+  });
+
+  it('should ensure that the trackDetails is not present & trackError is present when FETCH_TRACK_DETAILS_FAILED is dispatched', () => {
+    const error = translate('something_went_wrong');
+
+    const expectedResult = { ...state, trackError: error };
+
+    expect(
+      tuneContainerReducer(state, {
+        type: tuneContainerTypes.FAILURE_GET_TRACK_DETAILS,
+        error
+      })
+    ).toEqual(expectedResult);
+  });
 });

--- a/app/containers/TuneContainer/tests/reducer.test.js
+++ b/app/containers/TuneContainer/tests/reducer.test.js
@@ -50,7 +50,7 @@ describe('TuneContainer reducer tests', () => {
     ).toEqual(expectedResult);
   });
 
-  it('should ensure that the songData is empty when CLEAR_SONG is dispatched', () => {
+  it('should ensure that songsData is empty when CLEAR_SONG is dispatched', () => {
     const expectedResult = { ...state, songsData: [] };
     expect(
       tuneContainerReducer(state, {
@@ -60,7 +60,7 @@ describe('TuneContainer reducer tests', () => {
     ).toEqual(expectedResult);
   });
 
-  it('should return the state when an action of type FETCH_TRACK_DETAILS is dispatched', () => {
+  it('should update the state with songId when an action of type FETCH_TRACK_DETAILS is dispatched', () => {
     const songId = '918556408';
     const expectedResult = { ...state, songId };
 
@@ -72,7 +72,7 @@ describe('TuneContainer reducer tests', () => {
     ).toEqual(expectedResult);
   });
 
-  it('should ensure that the trackDetails is present when FETCH_TRACK_DETAILS_SUCCESS is dispatched', () => {
+  it('should ensure that the trackDetails is set when FETCH_TRACK_DETAILS_SUCCESS is dispatched', () => {
     const songId = '12212';
     const data = { name: 'Sia' };
     state = { ...state, songId };
@@ -86,7 +86,7 @@ describe('TuneContainer reducer tests', () => {
     ).toEqual(expectedResult);
   });
 
-  it('should ensure that the trackDetails is not present & trackError is present when FETCH_TRACK_DETAILS_FAILED is dispatched', () => {
+  it('should ensure that trackDetails empty & trackError is set when FETCH_TRACK_DETAILS_FAILED is dispatched', () => {
     const error = translate('something_went_wrong');
 
     const expectedResult = { ...state, trackError: error };

--- a/app/containers/TuneContainer/tests/saga.test.js
+++ b/app/containers/TuneContainer/tests/saga.test.js
@@ -66,9 +66,9 @@ describe('TuneContainer saga tests', () => {
   it('should ensure that the action SUCCESS_GET_TRACK_DETAILS is dispatched when the api call succeeds', () => {
     getTrackDetailsGenerator = getTrackDetails({ songId });
     getTrackDetailsGenerator.next().value;
-    const res2 = getTrackDetailsGenerator.next().value;
+    const resTwo = getTrackDetailsGenerator.next().value;
 
-    expect(res2).toEqual(call(getSongDetails, songId));
+    expect(resTwo).toEqual(call(getSongDetails, songId));
 
     const data = { results: [{ songId }] };
 
@@ -80,12 +80,12 @@ describe('TuneContainer saga tests', () => {
     );
   });
 
-  it('should ensure that the action FAILURE_GET_TRACK_DETAILS is dispatched when the api call succeeds', () => {
+  it('should ensure that the action FAILURE_GET_TRACK_DETAILS is dispatched when the api call fails', () => {
     getTrackDetailsGenerator = getTrackDetails({ songId });
     getTrackDetailsGenerator.next().value;
-    const res2 = getTrackDetailsGenerator.next().value;
+    const resTwo = getTrackDetailsGenerator.next().value;
 
-    expect(res2).toEqual(call(getSongDetails, songId));
+    expect(resTwo).toEqual(call(getSongDetails, songId));
     const error = translate('something_went_wrong');
 
     expect(getTrackDetailsGenerator.next(apiResponseGenerator(false, error)).value).toEqual(
@@ -97,14 +97,13 @@ describe('TuneContainer saga tests', () => {
   });
 
   it('should ensure that songsData is selected and SUCCESS_GET_TRACK_DETAILS is dispatched when songsData contains the trackId', () => {
-    getTrackDetailsGenerator = getTrackDetails({ songId, testData: songsData });
+    getTrackDetailsGenerator = getTrackDetails({ songId, testSongData: songsData });
     const res = getTrackDetailsGenerator.next().value;
 
-    const item = songsData.results.find((_song) => _song.trackId === songId);
     expect(res).toEqual(
       put({
         type: tuneContainerTypes.SUCCESS_GET_TRACK_DETAILS,
-        data: item
+        data: songsData.results[0]
       })
     );
   });

--- a/app/containers/TuneContainer/tests/saga.test.js
+++ b/app/containers/TuneContainer/tests/saga.test.js
@@ -97,7 +97,7 @@ describe('TuneContainer saga tests', () => {
   });
 
   it('should ensure that songsData is selected and SUCCESS_GET_TRACK_DETAILS is dispatched when songsData contains the trackId', () => {
-    getTrackDetailsGenerator = getTrackDetails({ songId, testSongData: songsData });
+    getTrackDetailsGenerator = getTrackDetails({ songId, songsDataCache: songsData });
     const res = getTrackDetailsGenerator.next().value;
 
     expect(res).toEqual(

--- a/app/containers/TuneContainer/tests/selectors.test.js
+++ b/app/containers/TuneContainer/tests/selectors.test.js
@@ -5,8 +5,7 @@ import {
   selectSongsError,
   selectTrackDetails,
   selectTrackError,
-  selectSongId,
-  selectTracksCache
+  selectSongId
 } from '../selectors';
 
 describe('TuneContainer selector tests', () => {
@@ -16,7 +15,7 @@ describe('TuneContainer selector tests', () => {
   let songsError;
   let trackError;
   let trackDetails;
-  let tracksCache;
+
   let songId;
 
   beforeEach(() => {
@@ -26,7 +25,6 @@ describe('TuneContainer selector tests', () => {
     songsError = 'There was some error while fetching the song information';
     trackError = 'Something went wrong';
     trackDetails = [{ songId }];
-    tracksCache = { songId: { artistName: 'Alan', url: 'https://abc2.mp3' } };
 
     mockedState = {
       tuneContainer: {
@@ -35,8 +33,7 @@ describe('TuneContainer selector tests', () => {
         songsError,
         songId,
         trackDetails,
-        trackError,
-        tracksCache
+        trackError
       }
     };
   });
@@ -72,10 +69,5 @@ describe('TuneContainer selector tests', () => {
   it('should select the songId', () => {
     const songIdSelector = selectSongId();
     expect(songIdSelector(mockedState)).toEqual(songId);
-  });
-
-  it('should select the tracksCache', () => {
-    const tracksCacheSelector = selectTracksCache();
-    expect(tracksCacheSelector(mockedState)).toEqual(tracksCache);
   });
 });

--- a/app/containers/TuneContainer/tests/selectors.test.js
+++ b/app/containers/TuneContainer/tests/selectors.test.js
@@ -1,21 +1,42 @@
-import { selectTuneContainer, selectSearchTerm, selectSongsData, selectSongsError } from '../selectors';
+import {
+  selectTuneContainer,
+  selectSearchTerm,
+  selectSongsData,
+  selectSongsError,
+  selectTrackDetails,
+  selectTrackError,
+  selectSongId,
+  selectTracksCache
+} from '../selectors';
 
 describe('TuneContainer selector tests', () => {
   let mockedState;
   let searchTerm;
   let songsData;
   let songsError;
+  let trackError;
+  let trackDetails;
+  let tracksCache;
+  let songId;
 
   beforeEach(() => {
     searchTerm = 'alanwalker';
     songsData = { totalResults: 1, results: [{ searchTerm }] };
+    songId = '212212';
     songsError = 'There was some error while fetching the song information';
+    trackError = 'Something went wrong';
+    trackDetails = [{ songId }];
+    tracksCache = { songId: { artistName: 'Alan', url: 'https://abc2.mp3' } };
 
     mockedState = {
       tuneContainer: {
         searchTerm,
         songsData,
-        songsError
+        songsError,
+        songId,
+        trackDetails,
+        trackError,
+        tracksCache
       }
     };
   });
@@ -36,5 +57,25 @@ describe('TuneContainer selector tests', () => {
   it('should select the songsError', () => {
     const songsErrorSelector = selectSongsError();
     expect(songsErrorSelector(mockedState)).toEqual(songsError);
+  });
+
+  it('should select the trackDetails', () => {
+    const trackDetailsSelector = selectTrackDetails();
+    expect(trackDetailsSelector(mockedState)).toEqual(trackDetails);
+  });
+
+  it('should select the trackError', () => {
+    const trackErrorSelector = selectTrackError();
+    expect(trackErrorSelector(mockedState)).toEqual(trackError);
+  });
+
+  it('should select the songId', () => {
+    const songIdSelector = selectSongId();
+    expect(songIdSelector(mockedState)).toEqual(songId);
+  });
+
+  it('should select the tracksCache', () => {
+    const tracksCacheSelector = selectTracksCache();
+    expect(tracksCacheSelector(mockedState)).toEqual(tracksCache);
   });
 });

--- a/app/routeConfig.js
+++ b/app/routeConfig.js
@@ -2,6 +2,7 @@ import NotFound from '@containers/NotFoundPage/Loadable';
 import HomeContainer from '@containers/HomeContainer/Loadable';
 import routeConstants from '@utils/routeConstants';
 import TuneContainer from '@containers/TuneContainer/Loadable';
+import TrackDetailContainer from '@containers/TuneContainer/TrackDetailContainer/Loadable';
 export const routeConfig = {
   repos: {
     component: HomeContainer,
@@ -10,6 +11,10 @@ export const routeConfig = {
   songs: {
     component: TuneContainer,
     ...routeConstants.songs
+  },
+  song: {
+    component: TrackDetailContainer,
+    ...routeConstants.song
   },
   notFoundPage: {
     component: NotFound,

--- a/app/services/repoApi.js
+++ b/app/services/repoApi.js
@@ -5,3 +5,4 @@ const songApi = generateApiClient('itunes');
 
 export const getRepos = (repoName) => repoApi.get(`/search/repositories?q=${repoName}`);
 export const getSongs = (searchTerm) => songApi.get(`/search?term=${searchTerm}`);
+export const getSongDetails = (songId) => songApi.get(`/lookup?id=${songId}`);

--- a/app/services/tests/repoApi.test.js
+++ b/app/services/tests/repoApi.test.js
@@ -1,6 +1,6 @@
 import MockAdapter from 'axios-mock-adapter';
 import { getApiClient } from '@utils/apiUtils';
-import { getRepos, getSongs } from '../repoApi';
+import { getRepos, getSongDetails, getSongs } from '../repoApi';
 
 describe('RepoApi tests', () => {
   const repositoryName = 'mac';
@@ -30,6 +30,18 @@ describe('SongApi tests', () => {
     ];
     mock.onGet(`/search?term=${searchTerm}`).reply(200, data);
     const res = await getSongs(searchTerm);
+    expect(res.data).toEqual(data);
+  });
+
+  it('songDetails Api should make the api call to "/lookup/id="', async () => {
+    const songId = '12112';
+    const mock = new MockAdapter(getApiClient('itunes').axiosInstance);
+    const data = {
+      songId
+    };
+
+    mock.onGet(`/lookup?id=${songId}`).reply(200, data);
+    const res = await getSongDetails(songId);
     expect(res.data).toEqual(data);
   });
 });

--- a/app/utils/routeConstants.js
+++ b/app/utils/routeConstants.js
@@ -1,6 +1,6 @@
 export default {
   repos: {
-    route: '/',
+    route: '/repos',
     props: {
       maxwidth: 500,
       padding: 20
@@ -8,7 +8,7 @@ export default {
     exact: true
   },
   songs: {
-    route: '/songs',
+    route: '/',
     props: {
       maxwidth: 500,
       padding: 20
@@ -16,7 +16,7 @@ export default {
     exact: true
   },
   song: {
-    route: '/songs/:songId',
+    route: '/:songId',
     props: {
       maxwidth: 500,
       padding: 20

--- a/app/utils/routeConstants.js
+++ b/app/utils/routeConstants.js
@@ -16,7 +16,7 @@ export default {
     exact: true
   },
   song: {
-    route: '/:songId',
+    route: '/songs/:songId',
     props: {
       maxwidth: 500,
       padding: 20

--- a/app/utils/routeConstants.js
+++ b/app/utils/routeConstants.js
@@ -14,5 +14,13 @@ export default {
       padding: 20
     },
     exact: true
+  },
+  song: {
+    route: '/songs/:songId',
+    props: {
+      maxwidth: 500,
+      padding: 20
+    },
+    exact: true
   }
 };

--- a/app/utils/testUtils.js
+++ b/app/utils/testUtils.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { browserHistory } from 'react-router-dom';
+import { browserHistory, BrowserRouter as Router } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import configureStore from '@app/configureStore';
 import { DEFAULT_LOCALE, translationMessages } from '@app/i18n';
@@ -12,7 +12,9 @@ import { IntlGlobalProvider } from '@components/IntlGlobalProvider';
 export const renderWithIntl = (children) =>
   render(
     <IntlProvider locale={DEFAULT_LOCALE} messages={translationMessages[DEFAULT_LOCALE]}>
-      <IntlGlobalProvider>{children}</IntlGlobalProvider>
+      <IntlGlobalProvider>
+        <Router>{children}</Router>
+      </IntlGlobalProvider>
     </IntlProvider>
   );
 


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description

---

This PR contains following section:-

 * Every song card can be clicked and user will be sent to the individual route of that song called TrackDetails page.
 *The Redux store maintains the cache storage of every details of the songs user clicked and it is responsible to check and 
 * dispatch API call if the trackDetails are not available inside cache.
 * More UI Updates in both Home and TrackDetails component.
 * More tests for each component

### Steps to Reproduce / Test

---
yarn test

### GIF's

---

![pr3test](https://user-images.githubusercontent.com/89914287/133598321-a1d2d88b-e035-43a3-9ba3-1c0e22f28987.gif)

![pr4track](https://user-images.githubusercontent.com/89914287/134015838-2ceb399d-cc1a-4022-9f5d-8480c31f528a.gif)


